### PR TITLE
Add githooks to project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '4.0.4'
     id 'application'
     id 'jacoco'
+    id "com.star-zero.gradle.githook" version "1.2.1"
 }
 
 mainClassName = 'seedu.address.Main'
@@ -67,6 +68,16 @@ dependencies {
 
 shadowJar {
     archiveName = 'addressbook.jar'
+}
+
+githook {
+    failOnMissingHooksDir = true
+    createHooksDirIfNotExist = true
+    hooks {
+        "pre-push" {
+            task = "test clean checkstyleMain checkStyleTest"
+        }
+    }
 }
 
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
Reason: Improve developer productivity, and prevent pushing code with bugs. 

Adds a `pre-push` hook that runs the following `gradle` tasks: `test`, `clean`, `checkstyleMain` and `checkstyleTest`. Did not add a `pre-commit` hook so that developers can cut down on commit time. 

Secured approval via [this issue](https://github.com/nus-cs2103-AY2021S1/forum/issues/201) filed on the GitHub forum for CS2103.