### PR TITLE
Change UI to our ResiReg design

### DIFF
--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -3,8 +3,10 @@ package seedu.address.ui;
 import static java.util.Objects.requireNonNull;
 
 import javafx.fxml.FXML;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextArea;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
 
 /**
  * A ui for the status bar that is displayed at the header of the application.
@@ -14,15 +16,26 @@ public class ResultDisplay extends UiPart<Region> {
     private static final String FXML = "ResultDisplay.fxml";
 
     @FXML
-    private TextArea resultDisplay;
+    private VBox responseContainer;
+    @FXML
+    private ScrollPane resultDisplayScroll;
 
+    /**
+     * Creates a ResultDisplay to display the result of a user's input.
+     */
     public ResultDisplay() {
         super(FXML);
+        resultDisplayScroll.vvalueProperty().bind(responseContainer.heightProperty());
     }
 
     public void setFeedbackToUser(String feedbackToUser) {
         requireNonNull(feedbackToUser);
-        resultDisplay.setText(feedbackToUser);
+        TextArea response = new TextArea(feedbackToUser);
+        response.setEditable(false);
+        response.getStyleClass().add("result-display");
+        responseContainer
+                .getChildren()
+                .add(response);
     }
 
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -149,8 +149,10 @@
 .result-display {
     -fx-background-color: transparent;
     -fx-font-family: "Segoe UI Light";
+    -fx-control-inner-background: derive(#1d1d1d, 20%);
     -fx-font-size: 13pt;
     -fx-text-fill: white;
+    -fx-pref-height: 30px;
 }
 
 .result-display .label {
@@ -349,4 +351,8 @@
     -fx-border-radius: 2;
     -fx-background-radius: 2;
     -fx-font-size: 11;
+}
+
+#responseContainer {
+    -fx-background-color: derive(#1d1d1d, 20%);
 }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -2,59 +2,87 @@
 
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.Scene?>
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.image.Image?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-
+<?import javafx.scene.Scene?>
+<?import javafx.stage.Stage?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
          title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
-  <icons>
-    <Image url="@/images/address_book_32.png" />
-  </icons>
-  <scene>
-    <Scene>
-      <stylesheets>
-        <URL value="@DarkTheme.css" />
-        <URL value="@Extensions.css" />
-      </stylesheets>
+    <icons>
+        <Image url="@/images/address_book_32.png"/>
+    </icons>
+    <scene>
+        <Scene>
+            <stylesheets>
+                <URL value="@DarkTheme.css"/>
+                <URL value="@Extensions.css"/>
+            </stylesheets>
 
-      <VBox>
-        <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
-          <Menu mnemonicParsing="false" text="File">
-            <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
-          </Menu>
-          <Menu mnemonicParsing="false" text="Help">
-            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
-          </Menu>
-        </MenuBar>
+            <GridPane>
+                <gridLinesVisible>true</gridLinesVisible>
+                <columnConstraints>
+                    <ColumnConstraints percentWidth="30"/>
+                    <ColumnConstraints percentWidth="70"/>
+                </columnConstraints>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
-          <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
-          </padding>
-        </StackPane>
+                <rowConstraints>
+                    <RowConstraints/>
+                    <RowConstraints vgrow="ALWAYS"/>
+                    <RowConstraints/>
+                </rowConstraints>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
-          <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
-          </padding>
-        </StackPane>
+                <MenuBar fx:id="menuBar"
+                         VBox.vgrow="NEVER"
+                         GridPane.columnIndex="0" GridPane.rowIndex="0" GridPane.columnSpan="2">
+                    <Menu mnemonicParsing="false" text="File">
+                        <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit"/>
+                    </Menu>
+                    <Menu mnemonicParsing="false" text="Help">
+                        <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help"/>
+                    </Menu>
+                </MenuBar>
 
-        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets top="10" right="10" bottom="10" left="10" />
-          </padding>
-          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-        </VBox>
+                <VBox alignment="BOTTOM_CENTER"
+                      GridPane.rowSpan="1" GridPane.columnSpan="1" GridPane.rowIndex="1" GridPane.columnIndex="0">
+                    <StackPane fx:id="resultDisplayPlaceholder"
+                               VBox.vgrow="ALWAYS"
+                               styleClass="pane-with-border">
+                        <padding>
+                            <Insets top="5" right="10" bottom="5" left="10"/>
+                        </padding>
+                    </StackPane>
 
-        <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
-      </VBox>
-    </Scene>
-  </scene>
+                    <StackPane fx:id="commandBoxPlaceholder"
+                               VBox.vgrow="NEVER"
+                               styleClass="pane-with-border">
+                        <padding>
+                            <Insets top="5" right="10" bottom="5" left="10"/>
+                        </padding>
+                    </StackPane>
+                </VBox>
+
+                <VBox fx:id="personList"
+                      VBox.vgrow="ALWAYS"
+                      styleClass="pane-with-border"
+                      minWidth="340" prefWidth="340"
+                      GridPane.columnIndex="1" GridPane.rowIndex="1" GridPane.rowSpan="2">
+                    <padding>
+                        <Insets top="10" right="10" bottom="10" left="10"/>
+                    </padding>
+                    <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                </VBox>
+
+                <StackPane fx:id="statusbarPlaceholder"
+                           VBox.vgrow="NEVER"
+                           GridPane.columnIndex="0" GridPane.rowIndex="3" GridPane.columnSpan="2"/>
+            </GridPane>
+        </Scene>
+    </scene>
 </fx:root>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.TextArea?>
-<?import javafx.scene.layout.StackPane?>
-
-<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8"
-    xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
-</StackPane>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.layout.VBox?>
+<ScrollPane fx:id="resultDisplayScroll"
+            styleClass="pane-with-border"
+            xmlns="http://javafx.com/javafx/8"
+            xmlns:fx="http://javafx.com/fxml/1"
+            hbarPolicy="NEVER"
+            fitToHeight="true"
+            fitToWidth="true"
+            hvalue="1">
+    <VBox fx:id="responseContainer"/>
+</ScrollPane>


### PR DESCRIPTION
This PR modifies the skeleton of our UI to match our mockup. I've shifted the cards to the right, and modified the results display to preserve its previous output, much like a chat.

There are styling issues (e.g. the corners of the results display), but I wouldn't let those block for v1.2.

![image](https://user-images.githubusercontent.com/22059033/94226012-16d4ac80-ff29-11ea-8384-dd65fe6962f3.png)
