### PR TITLE
Functionality Increment: Room Model

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id "com.star-zero.gradle.githook" version "1.2.1"
 }
 
-mainClassName = 'seedu.address.Main'
+mainClassName = 'seedu.resireg.Main'
 
 sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11

--- a/src/main/java/seedu/resireg/logic/Logic.java
+++ b/src/main/java/seedu/resireg/logic/Logic.java
@@ -8,6 +8,7 @@ import seedu.resireg.logic.commands.CommandResult;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.logic.parser.exceptions.ParseException;
 import seedu.resireg.model.ReadOnlyAddressBook;
+import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.Student;
 
 /**
@@ -32,6 +33,9 @@ public interface Logic {
 
     /** Returns an unmodifiable view of the filtered list of students */
     ObservableList<Student> getFilteredStudentList();
+
+    /** Returns an unmodifiable view of the filtered list of rooms */
+    ObservableList<Room> getFilteredRoomList();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/resireg/logic/LogicManager.java
+++ b/src/main/java/seedu/resireg/logic/LogicManager.java
@@ -14,6 +14,7 @@ import seedu.resireg.logic.parser.AddressBookParser;
 import seedu.resireg.logic.parser.exceptions.ParseException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ReadOnlyAddressBook;
+import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.Student;
 import seedu.resireg.storage.Storage;
 
@@ -62,6 +63,11 @@ public class LogicManager implements Logic {
     @Override
     public ObservableList<Student> getFilteredStudentList() {
         return model.getFilteredStudentList();
+    }
+
+    @Override
+    public ObservableList<Room> getFilteredRoomList() {
+        return model.getFilteredRoomList();
     }
 
     @Override

--- a/src/main/java/seedu/resireg/logic/commands/ListRoomCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ListRoomCommand.java
@@ -1,0 +1,23 @@
+package seedu.resireg.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.resireg.model.Model.PREDICATE_SHOW_ALL_ROOMS;
+
+import seedu.resireg.model.Model;
+
+/**
+ * Lists all rooms in the address book to the user.
+ */
+public class ListRoomCommand extends Command {
+    public static final String COMMAND_WORD = "rooms";
+
+    public static final String MESSAGE_SUCCESS = "Listed all rooms";
+
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredRoomList(PREDICATE_SHOW_ALL_ROOMS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/resireg/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.resireg.logic.commands.ExitCommand;
 import seedu.resireg.logic.commands.FindCommand;
 import seedu.resireg.logic.commands.HelpCommand;
 import seedu.resireg.logic.commands.ListCommand;
+import seedu.resireg.logic.commands.ListRoomCommand;
 import seedu.resireg.logic.parser.exceptions.ParseException;
 
 /**
@@ -61,6 +62,9 @@ public class AddressBookParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case ListRoomCommand.COMMAND_WORD:
+            return new ListRoomCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/resireg/model/AddressBook.java
+++ b/src/main/java/seedu/resireg/model/AddressBook.java
@@ -5,6 +5,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import javafx.collections.ObservableList;
+import seedu.resireg.model.room.Room;
+import seedu.resireg.model.room.UniqueRoomList;
 import seedu.resireg.model.student.Student;
 import seedu.resireg.model.student.UniqueStudentList;
 
@@ -15,6 +17,7 @@ import seedu.resireg.model.student.UniqueStudentList;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniqueStudentList students;
+    private final UniqueRoomList rooms;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -25,12 +28,13 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         students = new UniqueStudentList();
+        rooms = new UniqueRoomList();
     }
 
     public AddressBook() {}
 
     /**
-     * Creates an AddressBook using the Students in the {@code toBeCopied}
+     * Creates an AddressBook using the Students and Rooms in the {@code toBeCopied}
      */
     public AddressBook(ReadOnlyAddressBook toBeCopied) {
         this();
@@ -48,12 +52,22 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Replaces the contents of the room list with {@code rooms}.
+     * {@code rooms} must not contain duplicate rooms
+     */
+    public void setRooms(List<Room> rooms) {
+        this.rooms.setRooms(rooms);
+    }
+
+
+    /**
      * Resets the existing data of this {@code AddressBook} with {@code newData}.
      */
     public void resetData(ReadOnlyAddressBook newData) {
         requireNonNull(newData);
 
         setStudents(newData.getStudentList());
+        setRooms(newData.getRoomList());
     }
 
     //// student-level operations
@@ -94,6 +108,44 @@ public class AddressBook implements ReadOnlyAddressBook {
         students.remove(key);
     }
 
+    //// room-level operations
+
+    /**
+     * Adds a room to the address book.
+     * The room must not already exist in the address book.
+     */
+    public void addRoom(Room r) {
+        rooms.add(r);
+    }
+
+    /**
+     * Returns true if a room with the same identity as {@code room} exists in the address book.
+     */
+    public boolean hasRoom(Room room) {
+        requireNonNull(room);
+        return rooms.contains(room);
+    }
+
+    /**
+     * Replaces the given room {@code target} in the list with {@code editedRoom}.
+     * {@code target} must exist in the address book.
+     * The room identity of {@code editedStudent} must not be the same as another existing room
+     * in the address book.
+     */
+    public void setRoom(Room target, Room editedRoom) {
+        requireNonNull(editedRoom);
+
+        rooms.setRoom(target, editedRoom);
+    }
+
+    /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void removeRoom(Room key) {
+        rooms.remove(key);
+    }
+
     //// util methods
 
     @Override
@@ -108,10 +160,16 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
+    public ObservableList<Room> getRoomList() {
+        return rooms.asUnmodifiableObservableList();
+    }
+
+    @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof AddressBook // instanceof handles nulls
-                && students.equals(((AddressBook) other).students));
+                && students.equals(((AddressBook) other).students)
+                && rooms.equals(((AddressBook) other).rooms));
     }
 
     @Override

--- a/src/main/java/seedu/resireg/model/Model.java
+++ b/src/main/java/seedu/resireg/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.resireg.commons.core.GuiSettings;
+import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.Student;
 
 /**
@@ -13,6 +14,9 @@ import seedu.resireg.model.student.Student;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Student> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+
+    /** {@Code Predicate} that always evaluate to true */
+    Predicate<Room> PREDICATE_SHOW_ALL_ROOMS = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -80,9 +84,18 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered student list */
     ObservableList<Student> getFilteredStudentList();
 
+    /** Returns an unmodifiable view of the filtered room list */
+    ObservableList<Room> getFilteredRoomList();
+
     /**
      * Updates the filter of the filtered student list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredStudentList(Predicate<Student> predicate);
+
+    /**
+     * Updates the filter of the filtered room list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredRoomList(Predicate<Room> predicate);
 }

--- a/src/main/java/seedu/resireg/model/ModelManager.java
+++ b/src/main/java/seedu/resireg/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.resireg.commons.core.GuiSettings;
 import seedu.resireg.commons.core.LogsCenter;
+import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.Student;
 
 /**
@@ -22,6 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Student> filteredStudents;
+    private final FilteredList<Room> filteredRooms;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -35,6 +37,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredStudents = new FilteredList<>(this.addressBook.getStudentList());
+        filteredRooms = new FilteredList<>(this.addressBook.getRoomList());
     }
 
     public ModelManager() {
@@ -129,6 +132,23 @@ public class ModelManager implements Model {
         filteredStudents.setPredicate(predicate);
     }
 
+    //=========== Filtered Room List Accessors =============================================================
+
+    /**
+     * Returns an unmodifiable view of the list of {@code Room} backed by the internal list of
+     * {@code versionedAddressBook}
+     */
+    @Override
+    public ObservableList<Room> getFilteredRoomList() {
+        return filteredRooms;
+    }
+
+    @Override
+    public void updateFilteredRoomList(Predicate<Room> predicate) {
+        requireNonNull(predicate);
+        filteredRooms.setPredicate(predicate);
+    }
+
     @Override
     public boolean equals(Object obj) {
         // short circuit if same object
@@ -145,7 +165,8 @@ public class ModelManager implements Model {
         ModelManager other = (ModelManager) obj;
         return addressBook.equals(other.addressBook)
                 && userPrefs.equals(other.userPrefs)
-                && filteredStudents.equals(other.filteredStudents);
+                && filteredStudents.equals(other.filteredStudents)
+                && filteredRooms.equals(other.filteredRooms);
     }
 
 }

--- a/src/main/java/seedu/resireg/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/resireg/model/ReadOnlyAddressBook.java
@@ -1,6 +1,7 @@
 package seedu.resireg.model;
 
 import javafx.collections.ObservableList;
+import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.Student;
 
 /**
@@ -13,5 +14,9 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate students.
      */
     ObservableList<Student> getStudentList();
-
+    /**
+     * Returns an unmodifiable view of the rooms list.
+     * This list will not contain any duplicate rooms.
+     */
+    ObservableList<Room> getRoomList();
 }

--- a/src/main/java/seedu/resireg/model/room/Floor.java
+++ b/src/main/java/seedu/resireg/model/room/Floor.java
@@ -1,0 +1,54 @@
+package seedu.resireg.model.room;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.resireg.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a room's floor number in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidFloor(String)}
+ */
+public class Floor {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Floors should only contain numbers, cannot start with 0 and it should be at most 2 digits long";
+
+    public static final String VALIDATION_REGEX = "^[1-9][0-9]?$";
+    public final String value;
+
+    /**
+     * Constructs a {@code Floor}.
+     *
+     * @param floor A valid floor number.
+     */
+    public Floor(String floor) {
+        requireNonNull(floor);
+        checkArgument(isValidFloor(floor), MESSAGE_CONSTRAINTS);
+        value = floor;
+    }
+
+    /**
+     * Returns true if a given string is a valid floor number.
+     */
+    public static boolean isValidFloor(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof seedu.resireg.model.room.Floor // instanceof handles nulls
+                && value.equals(((seedu.resireg.model.room.Floor) other).value)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/resireg/model/room/Room.java
+++ b/src/main/java/seedu/resireg/model/room/Room.java
@@ -1,0 +1,113 @@
+package seedu.resireg.model.room;
+
+import static seedu.resireg.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import seedu.resireg.model.room.roomtype.RoomType;
+import seedu.resireg.model.tag.Tag;
+
+/**
+ * Represents a Room in ResiReg.
+ * Guarantees: details are present and not null, field values are validated, immutable.
+ */
+public class Room {
+
+    // Identity fields
+    private final Floor floor;
+    private final RoomNumber number;
+    private final RoomType roomType;
+
+    // Data fields
+    private final Set<Tag> tags = new HashSet<>();
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Room (Floor floor, RoomNumber number, RoomType roomType, Set<Tag> tags) {
+        requireAllNonNull(floor, number, roomType, tags);
+        this.floor = floor;
+        this.number = number;
+        this.roomType = roomType;
+        this.tags.addAll(tags);
+    }
+
+    public Floor getFloor() {
+        return floor;
+    }
+
+    public RoomNumber getRoomNumber() {
+        return number;
+    }
+
+    public RoomType getRoomType() {
+        return roomType;
+    }
+
+    /**
+     * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public Set<Tag> getTags() {
+        return Collections.unmodifiableSet(tags);
+    }
+
+    /**
+     * Returns true if both rooms have the same floor and room numbers.
+     * This defines a weaker notion of equality between two rooms, and includes rooms that have the same ID,
+     * but different fields (roomtype).
+     */
+    public boolean isSameRoom(Room otherRoom) {
+        if (otherRoom == this) {
+            return true;
+        }
+
+        return otherRoom != null && otherRoom.getFloor().equals(getFloor())
+                && otherRoom.getRoomNumber().equals(getRoomNumber());
+    }
+
+    /**
+     * Returns true if both rooms have the same data fields.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof seedu.resireg.model.room.Room)) {
+            return false;
+        }
+
+        seedu.resireg.model.room.Room otherRoom = (seedu.resireg.model.room.Room) other;
+        return otherRoom.getFloor().equals(getFloor())
+                && otherRoom.getRoomNumber().equals(getRoomNumber())
+                && otherRoom.getRoomType().equals(getRoomType())
+                && otherRoom.getTags().equals(getTags());
+    }
+
+    @Override
+    public int hashCode() {
+        // use this method for custom fields hashing instead of implementing your own
+        return Objects.hash(floor, number, roomType, tags);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(" Floor: ")
+                .append(getFloor())
+                .append(" Room Number: ")
+                .append(getRoomNumber())
+                .append(" Type: ")
+                .append(getRoomType())
+                .append(" Tags: ");
+        getTags().forEach(builder::append);
+        return builder.toString();
+    }
+
+}
+

--- a/src/main/java/seedu/resireg/model/room/RoomNumber.java
+++ b/src/main/java/seedu/resireg/model/room/RoomNumber.java
@@ -1,0 +1,55 @@
+package seedu.resireg.model.room;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.resireg.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a room's number in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidRoomNumber(String)}
+ */
+public class RoomNumber {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Room numbers should only contain numbers, cannot start with 0 "
+                    + "and it should be at most 3 digits long";
+
+    public static final String VALIDATION_REGEX = "^[1-9][0-9][0-9]$";
+    public final String value;
+
+    /**
+     * Constructs a {@code Number}.
+     *
+     * @param number A valid room number.
+     */
+    public RoomNumber(String number) {
+        requireNonNull(number);
+        checkArgument(isValidRoomNumber(number), MESSAGE_CONSTRAINTS);
+        value = number;
+    }
+
+    /**
+     * Returns true if a given string is a valid number.
+     */
+    public static boolean isValidRoomNumber(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof seedu.resireg.model.room.RoomNumber // instanceof handles nulls
+                && value.equals(((seedu.resireg.model.room.RoomNumber) other).value)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/resireg/model/room/UniqueRoomList.java
+++ b/src/main/java/seedu/resireg/model/room/UniqueRoomList.java
@@ -1,0 +1,138 @@
+package seedu.resireg.model.room;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.resireg.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.resireg.model.room.exceptions.DuplicateRoomException;
+import seedu.resireg.model.room.exceptions.RoomNotFoundException;
+
+/**
+ * A list of rooms that enforces uniqueness between its elements and does not allow nulls.
+ * A student is considered unique by comparing using {@code Room#isSameRoom(Room)}.
+ * As such, adding and updating of rooms uses Room#isSameRoom(Room) for equality so as to ensure
+ * that the room being added or updated is unique in terms of identity in the UniqueRoomList.
+ * However, the removal of a room uses Room#equals(Object) so as to ensure that the room with
+ * exactly the same fields will be removed.
+ *
+ * Supports a minimal set of list operations.
+ *
+ * @see Room#isSameRoom(Room)
+ */
+public class UniqueRoomList implements Iterable<Room> {
+
+    private final ObservableList<Room> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Room> internalImmutableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Returns true if the list contains an equivalent room as the given argument.
+     */
+    public boolean contains(Room toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameRoom);
+    }
+
+    /**
+     * Adds a room to the list.
+     * The room must not already exist in the list.
+     */
+    public void add(Room toAdd) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw new DuplicateRoomException();
+        }
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the room {@code target} in the list with {@code editedRoom}.
+     * {@code target} must exist in the list.
+     * The room identity of {@code editedRoom} must not be the same as another existing room in the list.
+     */
+    public void setRoom(Room target, Room editedRoom) {
+        requireAllNonNull(target, editedRoom);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new RoomNotFoundException();
+        }
+
+        if (!target.isSameRoom(editedRoom) && contains(editedRoom)) {
+            throw new DuplicateRoomException();
+        }
+
+        internalList.set(index, editedRoom);
+    }
+
+    /**
+     * Removes the equivalent room from the list.
+     * The room must exist in the list.
+     */
+    public void remove(Room toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new RoomNotFoundException();
+        }
+    }
+
+    public void setRooms(UniqueRoomList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    /**
+     * Replaces the contents of this list with {@code rooms}.
+     * {@code rooms} must not contain duplicate rooms.
+     */
+    public void setRooms(List<Room> rooms) {
+        requireAllNonNull(rooms);
+        if (!roomsAreUnique(rooms)) {
+            throw new DuplicateRoomException();
+        }
+
+        internalList.setAll(rooms);
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Room> asUnmodifiableObservableList() {
+        return internalImmutableList;
+    }
+
+    @Override
+    public Iterator<Room> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof seedu.resireg.model.room.UniqueRoomList // instanceof handles nulls
+                && internalList.equals(((seedu.resireg.model.room.UniqueRoomList) other).internalList));
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+
+    /**
+     * Returns true if {@code rooms} contains only unique rooms.
+     */
+    private boolean roomsAreUnique(List<Room> rooms) {
+        for (int i = 0; i < rooms.size() - 1; i++) {
+            for (int j = i + 1; j < rooms.size(); j++) {
+                if (rooms.get(i).isSameRoom(rooms.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/seedu/resireg/model/room/exceptions/DuplicateRoomException.java
+++ b/src/main/java/seedu/resireg/model/room/exceptions/DuplicateRoomException.java
@@ -1,0 +1,11 @@
+package seedu.resireg.model.room.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate rooms (Rooms are considered duplicates if they have the
+ * same identity).
+ */
+public class DuplicateRoomException extends RuntimeException {
+    public DuplicateRoomException() {
+        super("Operation would result in duplicate rooms");
+    }
+}

--- a/src/main/java/seedu/resireg/model/room/exceptions/RoomNotFoundException.java
+++ b/src/main/java/seedu/resireg/model/room/exceptions/RoomNotFoundException.java
@@ -1,0 +1,6 @@
+package seedu.resireg.model.room.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified room.
+ */
+public class RoomNotFoundException extends RuntimeException {}

--- a/src/main/java/seedu/resireg/model/room/roomtype/RoomType.java
+++ b/src/main/java/seedu/resireg/model/room/roomtype/RoomType.java
@@ -1,0 +1,57 @@
+package seedu.resireg.model.room.roomtype;
+
+import static seedu.resireg.commons.util.AppUtil.checkArgument;
+import static seedu.resireg.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Represents a room's type in ResiReg.
+ * Guarantees: immutable; is valid as declared in {@link #isValidRoomType(String)}
+ */
+public class RoomType {
+
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "A roomtype must be of the form \"CA\", \"CN\", \"NA\", or \"NN\".";
+
+    public final String name;
+
+    /**
+     * Constructs a {@code RoomType}.
+     *
+     * @param typeAbbr A valid room type abbreviation.
+     */
+    public RoomType(String typeAbbr) {
+        requireAllNonNull(typeAbbr);
+        checkArgument(isValidRoomType(typeAbbr), MESSAGE_CONSTRAINTS);
+        name = typeAbbr;
+    }
+
+    /**
+     * Returns true if a given string is a valid room type abbreviation.
+     */
+    public static boolean isValidRoomType(String test) {
+        List<RoomTypeEnum> roomTypes = Arrays.asList(RoomTypeEnum.values());
+        return roomTypes.stream().anyMatch(roomType -> roomType.matchesRoomTypeAbbreviation(test));
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RoomType // instanceof handles nulls
+                && name.equals(((RoomType) other).name));
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/resireg/model/room/roomtype/RoomTypeEnum.java
+++ b/src/main/java/seedu/resireg/model/room/roomtype/RoomTypeEnum.java
@@ -1,0 +1,26 @@
+package seedu.resireg.model.room.roomtype;
+
+public enum RoomTypeEnum {
+    CORRIDOR_AIRCON("CA", "$700"),
+    CORRIDOR_NONAIRCON("CN", "$500"),
+    NONCORRIDOR_AIRCON("NA", "$900"),
+    NONCORRIDOR_NONAIRCON("NN", "$650");
+
+    private String abbreviation;
+    private String fees;
+
+    RoomTypeEnum(String abbreviation, String fees) {
+        this.abbreviation = abbreviation;
+        this.fees = fees;
+    }
+
+    public boolean matchesRoomTypeAbbreviation(String test) {
+        return test.equals(abbreviation);
+    }
+
+    @Override
+    public String toString() {
+        return abbreviation;
+    }
+}
+

--- a/src/main/java/seedu/resireg/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/resireg/model/util/SampleDataUtil.java
@@ -6,6 +6,10 @@ import java.util.stream.Collectors;
 
 import seedu.resireg.model.AddressBook;
 import seedu.resireg.model.ReadOnlyAddressBook;
+import seedu.resireg.model.room.Floor;
+import seedu.resireg.model.room.Room;
+import seedu.resireg.model.room.RoomNumber;
+import seedu.resireg.model.room.roomtype.RoomType;
 import seedu.resireg.model.student.Email;
 import seedu.resireg.model.student.Name;
 import seedu.resireg.model.student.Phone;
@@ -41,10 +45,28 @@ public class SampleDataUtil {
         };
     }
 
+    public static Room[] getSampleRooms() {
+        return new Room[] {
+            new Room(new Floor("11"), new RoomNumber("108"), new RoomType("CA"),
+                    getTagSet("normal")),
+            new Room(new Floor("11"), new RoomNumber("104"), new RoomType("CN"),
+                    getTagSet("normal")),
+            new Room(new Floor("9"), new RoomNumber("102"), new RoomType("NN"),
+                    getTagSet("normal")),
+            new Room(new Floor("8"), new RoomNumber("107"), new RoomType("NA"),
+                    getTagSet("room")),
+            new Room(new Floor("7"), new RoomNumber("106"), new RoomType("CN"),
+                    getTagSet("hello"))
+        };
+    }
+
     public static ReadOnlyAddressBook getSampleAddressBook() {
         AddressBook sampleAb = new AddressBook();
         for (Student sampleStudent : getSampleStudents()) {
             sampleAb.addStudent(sampleStudent);
+        }
+        for (Room sampleRoom : getSampleRooms()) {
+            sampleAb.addRoom(sampleRoom);
         }
         return sampleAb;
     }

--- a/src/main/java/seedu/resireg/storage/JsonAdaptedRoom.java
+++ b/src/main/java/seedu/resireg/storage/JsonAdaptedRoom.java
@@ -1,0 +1,99 @@
+package seedu.resireg.storage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.resireg.commons.exceptions.IllegalValueException;
+import seedu.resireg.model.room.Floor;
+import seedu.resireg.model.room.Room;
+import seedu.resireg.model.room.RoomNumber;
+import seedu.resireg.model.room.roomtype.RoomType;
+import seedu.resireg.model.tag.Tag;
+
+/**
+ * Jackson-friendly version of {@link Room}.
+ */
+class JsonAdaptedRoom {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Room's %s field is missing!";
+
+    private final String floor;
+    private final String roomNumber;
+    private final String roomType;
+    private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonAdaptedRoom} with the given room details.
+     */
+    @JsonCreator
+    public JsonAdaptedRoom(@JsonProperty("floor") String floor, @JsonProperty("roomNumber") String number,
+                           @JsonProperty("roomType") String roomType,
+                           @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+        this.floor = floor;
+        this.roomNumber = number;
+        this.roomType = roomType;
+        if (tagged != null) {
+            this.tagged.addAll(tagged);
+        }
+    }
+
+    /**
+     * Converts a given {@code Room} into this class for Jackson use.
+     */
+    public JsonAdaptedRoom(Room source) {
+        floor = source.getFloor().value;
+        roomNumber = source.getRoomNumber().value;
+        roomType = source.getRoomType().name;
+        tagged.addAll(source.getTags().stream()
+                .map(JsonAdaptedTag::new)
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted room object into the model's {@code Room} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted room.
+     */
+    public Room toModelType() throws IllegalValueException {
+        final List<Tag> roomTags = new ArrayList<>();
+        for (JsonAdaptedTag tag : tagged) {
+            roomTags.add(tag.toModelType());
+        }
+
+        if (floor == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Floor.class.getSimpleName()));
+        }
+        if (!Floor.isValidFloor(floor)) {
+            throw new IllegalValueException(Floor.MESSAGE_CONSTRAINTS);
+        }
+        final Floor modelFloor = new Floor(floor);
+
+        if (roomNumber == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Number.class.getSimpleName()));
+        }
+        if (!RoomNumber.isValidRoomNumber(roomNumber)) {
+            throw new IllegalValueException(RoomNumber.MESSAGE_CONSTRAINTS);
+        }
+        final RoomNumber modelNumber = new RoomNumber(roomNumber);
+
+        if (roomType == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    RoomType.class.getSimpleName()));
+        }
+        if (!RoomType.isValidRoomType(roomType)) {
+            throw new IllegalValueException(RoomType.MESSAGE_CONSTRAINTS);
+        }
+        final RoomType modelRoomType = new RoomType(roomType);
+
+        final Set<Tag> modelTags = new HashSet<>(roomTags);
+        return new Room(modelFloor, modelNumber, modelRoomType, modelTags);
+    }
+
+}
+

--- a/src/main/java/seedu/resireg/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/resireg/storage/JsonSerializableAddressBook.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import seedu.resireg.commons.exceptions.IllegalValueException;
 import seedu.resireg.model.AddressBook;
 import seedu.resireg.model.ReadOnlyAddressBook;
+import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.Student;
 
 /**
@@ -20,8 +21,10 @@ import seedu.resireg.model.student.Student;
 class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Students list contains duplicate student(s).";
+    public static final String MESSAGE_DUPLICATE_ROOM = "Rooms list contains duplicate room(s).";
 
     private final List<JsonAdaptedStudent> students = new ArrayList<>();
+    private final List<JsonAdaptedRoom> rooms = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableAddressBook} with the given students.
@@ -29,6 +32,7 @@ class JsonSerializableAddressBook {
     @JsonCreator
     public JsonSerializableAddressBook(@JsonProperty("students") List<JsonAdaptedStudent> students) {
         this.students.addAll(students);
+        this.rooms.addAll(rooms);
     }
 
     /**
@@ -38,6 +42,7 @@ class JsonSerializableAddressBook {
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
         students.addAll(source.getStudentList().stream().map(JsonAdaptedStudent::new).collect(Collectors.toList()));
+        rooms.addAll(source.getRoomList().stream().map(JsonAdaptedRoom::new).collect(Collectors.toList()));
     }
 
     /**
@@ -53,6 +58,13 @@ class JsonSerializableAddressBook {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
             addressBook.addStudent(student);
+        }
+        for (JsonAdaptedRoom jsonAdaptedRoom : rooms) {
+            Room room = jsonAdaptedRoom.toModelType();
+            if (addressBook.hasRoom(room)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_ROOM);
+            }
+            addressBook.addRoom(room);
         }
         return addressBook;
     }

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidStudentAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidStudentAddressBook.json
@@ -1,14 +1,18 @@
 {
-  "students": [ {
-    "name": "Valid Person",
-    "phone": "9482424",
-    "email": "hans@example.com",
-    "faculty": "FASS",
-    "studentId": "E0407881"
-  }, {
-    "name": "Person With Invalid Phone Field",
-    "phone": "948asdf2424",
-    "faculty": "FASS",
-    "studentId": "E0407881"
-  } ]
+  "students": [
+    {
+      "name": "Valid Person",
+      "phone": "9482424",
+      "email": "hans@example.com",
+      "faculty": "FASS",
+      "studentId": "E0407881"
+    },
+    {
+      "name": "Person With Invalid Phone Field",
+      "phone": "948asdf2424",
+      "faculty": "FASS",
+      "studentId": "E0407881"
+    }
+  ],
+  "rooms": []
 }

--- a/src/test/data/JsonAddressBookStorageTest/invalidStudentAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidStudentAddressBook.json
@@ -1,9 +1,12 @@
 {
-  "students": [ {
-    "name": "Person with invalid name field: Ha!ns Mu@ster",
-    "phone": "9482424",
-    "email": "hans@example.com",
-    "faculty": "FASS",
-    "studentId": "E0407881"
-  } ]
+  "students": [
+    {
+      "name": "Person with invalid name field: Ha!ns Mu@ster",
+      "phone": "9482424",
+      "email": "hans@example.com",
+      "faculty": "FASS",
+      "studentId": "E0407881"
+    }
+  ],
+  "rooms": []
 }

--- a/src/test/java/seedu/resireg/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/AddCommandTest.java
@@ -20,6 +20,7 @@ import seedu.resireg.model.AddressBook;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ReadOnlyAddressBook;
 import seedu.resireg.model.ReadOnlyUserPrefs;
+import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.Student;
 import seedu.resireg.testutil.StudentBuilder;
 
@@ -144,7 +145,17 @@ public class AddCommandTest {
         }
 
         @Override
+        public ObservableList<Room> getFilteredRoomList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updateFilteredStudentList(Predicate<Student> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredRoomList(Predicate<Room> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/resireg/logic/commands/ListRoomCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/ListRoomCommandTest.java
@@ -1,0 +1,10 @@
+package seedu.resireg.logic.commands;
+
+import org.junit.jupiter.api.Test;
+
+class ListRoomCommandTest {
+
+    @Test
+    void execute() {
+    }
+}

--- a/src/test/java/seedu/resireg/model/AddressBookTest.java
+++ b/src/test/java/seedu/resireg/model/AddressBookTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.Student;
 import seedu.resireg.model.student.exceptions.DuplicateStudentException;
 import seedu.resireg.testutil.StudentBuilder;
@@ -88,14 +89,20 @@ public class AddressBookTest {
      */
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Student> students = FXCollections.observableArrayList();
+        private final ObservableList<Room> rooms = FXCollections.observableArrayList();
 
         AddressBookStub(Collection<Student> students) {
-            this.students.setAll(students);
+            this.students.setAll(students); // todo: set rooms
         }
 
         @Override
         public ObservableList<Student> getStudentList() {
             return students;
+        }
+
+        @Override
+        public ObservableList<Room> getRoomList() {
+            return rooms;
         }
     }
 

--- a/src/test/java/seedu/resireg/model/room/FloorTest.java
+++ b/src/test/java/seedu/resireg/model/room/FloorTest.java
@@ -1,0 +1,40 @@
+package seedu.resireg.model.room;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.resireg.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class FloorTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Floor(null));
+    }
+
+    @Test
+    public void constructor_invalidFloor_throwsIllegalArgumentException() {
+        String invalidFloor = "";
+        assertThrows(IllegalArgumentException.class, () -> new Floor(invalidFloor));
+    }
+
+    @Test
+    void isValidFloor() {
+        // null name
+        assertThrows(NullPointerException.class, () -> Floor.isValidFloor(null));
+
+        // invalid floor
+        assertFalse(Floor.isValidFloor("")); // empty string
+        assertFalse(Floor.isValidFloor(" ")); // spaces only
+        assertFalse(Floor.isValidFloor("^")); // only non-numeric characters
+        assertFalse(Floor.isValidFloor("1*")); // contains non-numeric characters
+        assertFalse(Floor.isValidFloor("123")); // contains 3 digits
+        assertFalse(Floor.isValidFloor("01")); // starts with 0
+
+        // valid floor
+        assertTrue(Floor.isValidFloor("12")); // 2 digits
+        assertTrue(Floor.isValidFloor("9")); // 1 digit
+    }
+
+}

--- a/src/test/java/seedu/resireg/model/room/RoomNumberTest.java
+++ b/src/test/java/seedu/resireg/model/room/RoomNumberTest.java
@@ -1,0 +1,41 @@
+package seedu.resireg.model.room;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.resireg.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class RoomNumberTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new RoomNumber(null));
+    }
+
+    @Test
+    public void constructor_invalidRoomNumber_throwsIllegalArgumentException() {
+        String invalidRoomNumber = "";
+        assertThrows(IllegalArgumentException.class, () -> new RoomNumber(invalidRoomNumber));
+    }
+
+    @Test
+    void isValidRoomNumber() {
+        // null name
+        assertThrows(NullPointerException.class, () -> RoomNumber.isValidRoomNumber(null));
+
+        // invalid floor
+        assertFalse(RoomNumber.isValidRoomNumber("")); // empty string
+        assertFalse(RoomNumber.isValidRoomNumber(" ")); // spaces only
+        assertFalse(RoomNumber.isValidRoomNumber("^")); // only non-numeric characters
+        assertFalse(RoomNumber.isValidRoomNumber("1*")); // contains non-numeric characters
+        assertFalse(RoomNumber.isValidRoomNumber("1")); // contains 1 digit
+        assertFalse(RoomNumber.isValidRoomNumber("12")); // contains 2 digits
+        assertFalse(RoomNumber.isValidRoomNumber("012")); // starts with 0
+
+        // valid floor
+        assertTrue(RoomNumber.isValidRoomNumber("123")); // small number
+        assertTrue(RoomNumber.isValidRoomNumber("450")); // medium number
+        assertTrue(RoomNumber.isValidRoomNumber("912")); // big number
+    }
+}

--- a/src/test/java/seedu/resireg/model/room/RoomTest.java
+++ b/src/test/java/seedu/resireg/model/room/RoomTest.java
@@ -1,0 +1,26 @@
+package seedu.resireg.model.room;
+
+import org.junit.jupiter.api.Test;
+
+class RoomTest {
+
+    @Test
+    void getFloor() {
+    }
+
+    @Test
+    void getRoomNumber() {
+    }
+
+    @Test
+    void getRoomType() {
+    }
+
+    @Test
+    void getTags() {
+    }
+
+    @Test
+    void isSameRoom() {
+    }
+}

--- a/src/test/java/seedu/resireg/model/room/UniqueRoomListTest.java
+++ b/src/test/java/seedu/resireg/model/room/UniqueRoomListTest.java
@@ -1,0 +1,34 @@
+package seedu.resireg.model.room;
+
+import org.junit.jupiter.api.Test;
+
+class UniqueRoomListTest {
+
+    @Test
+    void contains() {
+    }
+
+    @Test
+    void add() {
+    }
+
+    @Test
+    void setRoom() {
+    }
+
+    @Test
+    void remove() {
+    }
+
+    @Test
+    void setRooms() {
+    }
+
+    @Test
+    void testSetRooms() {
+    }
+
+    @Test
+    void asUnmodifiableObservableList() {
+    }
+}

--- a/src/test/java/seedu/resireg/model/room/roomtype/RoomTypeTest.java
+++ b/src/test/java/seedu/resireg/model/room/roomtype/RoomTypeTest.java
@@ -1,0 +1,38 @@
+package seedu.resireg.model.room.roomtype;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.resireg.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class RoomTypeTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new RoomType(null));
+    }
+
+    @Test
+    public void constructor_invalidAddress_throwsIllegalArgumentException() {
+        String invalidRoomType = "";
+        assertThrows(IllegalArgumentException.class, () -> new RoomType(invalidRoomType));
+    }
+
+    @Test
+    public void isValidRoomType() {
+        // null roomtype
+        assertThrows(NullPointerException.class, () -> RoomType.isValidRoomType(null));
+
+        // invalid roomtypes
+        assertFalse(RoomType.isValidRoomType("")); // empty string
+        assertFalse(RoomType.isValidRoomType(" ")); // spaces only
+        assertFalse(RoomType.isValidRoomType("dnfj")); // invalid roomtype abbreviation
+
+        // valid roomtypes
+        assertTrue(RoomType.isValidRoomType("CA"));
+        assertTrue(RoomType.isValidRoomType("CN"));
+        assertTrue(RoomType.isValidRoomType("NA"));
+        assertTrue(RoomType.isValidRoomType("NN"));
+    }
+}

--- a/src/test/java/seedu/resireg/storage/JsonAdaptedRoomTest.java
+++ b/src/test/java/seedu/resireg/storage/JsonAdaptedRoomTest.java
@@ -1,0 +1,10 @@
+package seedu.resireg.storage;
+
+import org.junit.jupiter.api.Test;
+
+class JsonAdaptedRoomTest {
+
+    @Test
+    void toModelType() {
+    }
+}

--- a/src/test/java/seedu/resireg/testutil/RoomBuilder.java
+++ b/src/test/java/seedu/resireg/testutil/RoomBuilder.java
@@ -1,0 +1,83 @@
+package seedu.resireg.testutil;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import seedu.resireg.model.room.Floor;
+import seedu.resireg.model.room.Room;
+import seedu.resireg.model.room.RoomNumber;
+import seedu.resireg.model.room.roomtype.RoomType;
+import seedu.resireg.model.tag.Tag;
+import seedu.resireg.model.util.SampleDataUtil;
+
+/**
+ * A utility class to help with building Student objects.
+ */
+public class RoomBuilder {
+
+    public static final String DEFAULT_FLOOR = "8";
+    public static final String DEFAULT_ROOM_NUMBER = "105";
+    public static final String DEFAULT_ROOM_TYPE = "CN";
+
+    private Floor floor;
+    private RoomNumber roomNumber;
+    private RoomType roomType;
+    private Set<Tag> tags;
+
+    /**
+     * Creates a {@code RoomBuilder} with the default details.
+     */
+    public RoomBuilder() {
+        floor = new Floor(DEFAULT_FLOOR);
+        roomNumber = new RoomNumber(DEFAULT_ROOM_NUMBER);
+        roomType = new RoomType(DEFAULT_ROOM_TYPE);
+        tags = new HashSet<>();
+    }
+
+    /**
+     * Initializes the RoomBuilder with the data of {@code roomToCopy}.
+     */
+    public RoomBuilder(Room roomToCopy) {
+        floor = roomToCopy.getFloor();
+        roomNumber = roomToCopy.getRoomNumber();
+        roomType = roomToCopy.getRoomType();
+        tags = new HashSet<>(roomToCopy.getTags());
+    }
+
+    /**
+     * Sets the {@code Floor} of the {@code Room} that we are building.
+     */
+    public RoomBuilder withName(String floor) {
+        this.floor = new Floor(floor);
+        return this;
+    }
+
+    /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Room} that we are building.
+     */
+    public RoomBuilder withTags(String ... tags) {
+        this.tags = SampleDataUtil.getTagSet(tags);
+        return this;
+    }
+
+    /**
+     * Sets the {@code RoomType} of the {@code Student} that we are building.
+     */
+    public RoomBuilder withRoomType(String type) {
+        this.roomType = new RoomType(type);
+        return this;
+    }
+
+    /**
+     * Sets the {@code RoomNumber} of the {@code Room} that we are building.
+     */
+    public RoomBuilder withRoomNumber(String number) {
+        this.roomNumber = new RoomNumber(number);
+        return this;
+    }
+
+    public Room build() {
+        return new Room(floor, roomNumber, roomType, tags);
+    }
+
+}


### PR DESCRIPTION
This PR adds the functionality increment of the Room Model. As of now RoomType is implemented with RoomTypeEnum which lists the possible room types, as well as their semester fees, but these fees are tucked away in the enum. 

I am unsure as to how to implement RoomType in such a way that it has both its constituent type and semester fees, and its argument string validated (somewhere between a student and phone number in terms of validation, if I am understanding it correctly). 

Changes made:
* Add `Room` model, as well as 3 attributes
  * `RoomType` (contains 4 possible options defined in `RoomTypeEnum`)
  * `RoomNumber` (room number of the form `exactly 3 digits, and cannot start with 0`)
  * `Floor` (floor of the room, in the form `1 or 2 digits, and cannot start with 0`)

* Add `JsonAdaptedRoom` class for conversion of room objects to json for storage and vice versa

* Add `ListRoomsCommand` using the syntax `rooms` as mentioned in the User Guide. As of now, it just outputs the success message as the UI for rooms has not been set up yet.

* Slight Modifications to `Logic`, `LogicManager`, `AddressBook`, `Model`, `ModelManager`, `JsonSerializableAddressBook` to ensure that the `UniqueRoomList rooms` is populated upon startup

* Add `RoomBuilder` class to help with testing of `Room` and `UniqueRoomList`.

* Add testing support for `Floor`, `RoomType` and `RoomNumber`. 

Not yet done:
* Add testing support for `Room`, `UniqueRoomList`, `JsonAdaptedRoom`, `ListRoomsCommand` and potentially `JsonSerializableAddressBook`, latter for rooms
* Add Add, Edit and Delete commands, including testing support

As part of #73 