### PR TITLE
Point CI badge to T16-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![Java CI](https://github.com/AY2021S1-CS2103-T16-3/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2021S1-CS2103-T16-3/tp/actions)
 
 ![Ui](docs/images/Ui.png)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: page
 title: ResiReg
 ---
 
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![Java CI](https://github.com/AY2021S1-CS2103-T16-3/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2021S1-CS2103-T16-3/tp/actions)
 
 ![Ui](images/Ui.png)
 


### PR DESCRIPTION
The CI badges in README and docs were still referencing AddressBook. This commit amends that.