### PR TITLE
Functionality Increment: Allocate Command

### DIFF
--- a/src/main/java/seedu/resireg/commons/core/Messages.java
+++ b/src/main/java/seedu/resireg/commons/core/Messages.java
@@ -9,5 +9,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The student index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d students listed!";
+    public static final String MESSAGE_INVALID_ROOM_DISPLAYED_INDEX = "The room index provided is invalid";
 
 }

--- a/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
@@ -1,0 +1,84 @@
+package seedu.resireg.logic.commands;
+
+import seedu.resireg.commons.core.Messages;
+import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.commands.exceptions.CommandException;
+import seedu.resireg.model.Model;
+import seedu.resireg.model.room.Room;
+import seedu.resireg.model.student.Student;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.resireg.logic.parser.CliSyntax.*;
+
+/**
+ * Adds a student to the address book.
+ */
+public class AllocateCommand extends Command {
+
+    public static final String COMMAND_WORD = "allocate";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Allocates a student to a room. "
+            + "Parameters: "
+            + PREFIX_STUDENT_INDEX + "STUDENT INDEX "
+            + PREFIX_ROOM_INDEX + "ROOM INDEX"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_STUDENT_INDEX + "1 "
+            + PREFIX_ROOM_INDEX + "1";
+
+    public static final String MESSAGE_SUCCESS = "Room allocated to %1$s: %2$s";
+    public static final String MESSAGE_ROOM_NOT_FOUND = "This room does not exist in ResiReg";
+    public static final String MESSAGE_STUDENT_NOT_FOUND = "This student is not registered in ResiReg";
+    public static final String MESSAGE_STUDENT_ALREADY_ALLOCATED = "This student has already been allocated a room.";
+
+    private final Index studentIndex;
+    private final Index roomIndex;
+
+    /**
+     * @param studentIndex of the student in the filtered student list to allocate
+     * @param roomIndex of the room in the filtered room list to be allocated to
+     * Creates an AllocateCommand to allocate the specified {@code Student} to {@code Room}
+     */
+    public AllocateCommand(Index studentIndex, Index roomIndex) {
+        requireNonNull(studentIndex);
+        requireNonNull(roomIndex);
+
+        this.studentIndex = studentIndex;
+        this.roomIndex = roomIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Student> lastShownListStudent = model.getFilteredStudentList();
+        List<Room> lastShownListRoom = model.getFilteredRoomList();
+
+        if (studentIndex.getZeroBased() >= lastShownListStudent.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        } else if (roomIndex.getZeroBased() >= lastShownListRoom.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_ROOM_DISPLAYED_INDEX);
+        }
+
+        Student studentToAllocate = lastShownListStudent.get(studentIndex.getZeroBased());
+        Room roomToAllocate = lastShownListRoom.get(roomIndex.getZeroBased());
+
+        if (!model.hasStudent(studentToAllocate)) {
+            throw new CommandException(MESSAGE_STUDENT_NOT_FOUND);
+        } else if (!model.hasRoom(roomToAllocate)){
+            throw new CommandException(MESSAGE_ROOM_NOT_FOUND);
+        } else if (studentToAllocate.hasRoom()) {
+            throw new CommandException(MESSAGE_STUDENT_ALREADY_ALLOCATED);
+        }
+
+        studentToAllocate.setRoom(roomToAllocate);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, studentToAllocate, roomToAllocate));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AllocateCommand // instanceof handles nulls
+                && studentIndex.equals(((AllocateCommand) other).studentIndex)
+                && roomIndex.equals(((AllocateCommand) other).roomIndex));
+    }
+}

--- a/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
@@ -1,5 +1,11 @@
 package seedu.resireg.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_ROOM_INDEX;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_STUDENT_INDEX;
+
+import java.util.List;
+
 import seedu.resireg.commons.core.Messages;
 import seedu.resireg.commons.core.index.Index;
 import seedu.resireg.logic.commands.exceptions.CommandException;
@@ -7,10 +13,6 @@ import seedu.resireg.model.Model;
 import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.Student;
 
-import java.util.List;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.resireg.logic.parser.CliSyntax.*;
 
 /**
  * Adds a student to the address book.
@@ -64,7 +66,7 @@ public class AllocateCommand extends Command {
 
         if (!model.hasStudent(studentToAllocate)) {
             throw new CommandException(MESSAGE_STUDENT_NOT_FOUND);
-        } else if (!model.hasRoom(roomToAllocate)){
+        } else if (!model.hasRoom(roomToAllocate)) {
             throw new CommandException(MESSAGE_ROOM_NOT_FOUND);
         } else if (studentToAllocate.hasRoom()) {
             throw new CommandException(MESSAGE_STUDENT_ALREADY_ALLOCATED);

--- a/src/main/java/seedu/resireg/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/AddressBookParser.java
@@ -6,16 +6,7 @@ import static seedu.resireg.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.resireg.logic.commands.AddCommand;
-import seedu.resireg.logic.commands.ClearCommand;
-import seedu.resireg.logic.commands.Command;
-import seedu.resireg.logic.commands.DeleteCommand;
-import seedu.resireg.logic.commands.EditCommand;
-import seedu.resireg.logic.commands.ExitCommand;
-import seedu.resireg.logic.commands.FindCommand;
-import seedu.resireg.logic.commands.HelpCommand;
-import seedu.resireg.logic.commands.ListCommand;
-import seedu.resireg.logic.commands.ListRoomCommand;
+import seedu.resireg.logic.commands.*;
 import seedu.resireg.logic.parser.exceptions.ParseException;
 
 /**
@@ -71,6 +62,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case AllocateCommand.COMMAND_WORD:
+            return new AllocateCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/resireg/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/AddressBookParser.java
@@ -6,7 +6,17 @@ import static seedu.resireg.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.resireg.logic.commands.*;
+import seedu.resireg.logic.commands.AddCommand;
+import seedu.resireg.logic.commands.AllocateCommand;
+import seedu.resireg.logic.commands.ClearCommand;
+import seedu.resireg.logic.commands.Command;
+import seedu.resireg.logic.commands.DeleteCommand;
+import seedu.resireg.logic.commands.EditCommand;
+import seedu.resireg.logic.commands.ExitCommand;
+import seedu.resireg.logic.commands.FindCommand;
+import seedu.resireg.logic.commands.HelpCommand;
+import seedu.resireg.logic.commands.ListCommand;
+import seedu.resireg.logic.commands.ListRoomCommand;
 import seedu.resireg.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/resireg/logic/parser/AllocateCommandParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/AllocateCommandParser.java
@@ -1,20 +1,13 @@
 package seedu.resireg.logic.parser;
 
-import seedu.resireg.commons.core.index.Index;
-import seedu.resireg.logic.commands.AddCommand;
-import seedu.resireg.logic.commands.AllocateCommand;
-import seedu.resireg.logic.parser.exceptions.ParseException;
-import seedu.resireg.model.room.Floor;
-import seedu.resireg.model.room.Room;
-import seedu.resireg.model.room.RoomNumber;
-import seedu.resireg.model.student.*;
-import seedu.resireg.model.tag.Tag;
-
-import java.util.Set;
-import java.util.stream.Stream;
-
 import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.resireg.logic.parser.CliSyntax.*;
+
+import java.util.stream.Stream;
+
+import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.commands.AllocateCommand;
+import seedu.resireg.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new AddCommand object
@@ -30,7 +23,7 @@ public class AllocateCommandParser implements Parser<AllocateCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_STUDENT_INDEX, PREFIX_ROOM_INDEX);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_STUDENT_INDEX)
+        if (!arePrefixesPresent(argMultimap, PREFIX_STUDENT_INDEX, PREFIX_ROOM_INDEX)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AllocateCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/resireg/logic/parser/AllocateCommandParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/AllocateCommandParser.java
@@ -1,7 +1,8 @@
 package seedu.resireg.logic.parser;
 
 import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.resireg.logic.parser.CliSyntax.*;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_ROOM_INDEX;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_STUDENT_INDEX;
 
 import java.util.stream.Stream;
 

--- a/src/main/java/seedu/resireg/logic/parser/AllocateCommandParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/AllocateCommandParser.java
@@ -1,0 +1,56 @@
+package seedu.resireg.logic.parser;
+
+import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.commands.AddCommand;
+import seedu.resireg.logic.commands.AllocateCommand;
+import seedu.resireg.logic.parser.exceptions.ParseException;
+import seedu.resireg.model.room.Floor;
+import seedu.resireg.model.room.Room;
+import seedu.resireg.model.room.RoomNumber;
+import seedu.resireg.model.student.*;
+import seedu.resireg.model.tag.Tag;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.resireg.logic.parser.CliSyntax.*;
+
+/**
+ * Parses input arguments and creates a new AddCommand object
+ */
+public class AllocateCommandParser implements Parser<AllocateCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand
+     * and returns an AddCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AllocateCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_STUDENT_INDEX, PREFIX_ROOM_INDEX);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_STUDENT_INDEX)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AllocateCommand.MESSAGE_USAGE));
+        }
+
+        try {
+            Index studentIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_STUDENT_INDEX).get());
+            Index roomIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_ROOM_INDEX).get());
+            return new AllocateCommand(studentIndex, roomIndex);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AllocateCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/resireg/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/resireg/logic/parser/CliSyntax.java
@@ -12,5 +12,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_FACULTY = new Prefix("f/");
     public static final Prefix PREFIX_STUDENT_ID = new Prefix("i/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-
+    public static final Prefix PREFIX_STUDENT_INDEX = new Prefix("si/");
+    public static final Prefix PREFIX_ROOM_INDEX = new Prefix("ri/");
 }

--- a/src/main/java/seedu/resireg/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/resireg/logic/parser/ParserUtil.java
@@ -9,6 +9,8 @@ import java.util.Set;
 import seedu.resireg.commons.core.index.Index;
 import seedu.resireg.commons.util.StringUtil;
 import seedu.resireg.logic.parser.exceptions.ParseException;
+import seedu.resireg.model.room.Floor;
+import seedu.resireg.model.room.RoomNumber;
 import seedu.resireg.model.student.Email;
 import seedu.resireg.model.student.Name;
 import seedu.resireg.model.student.Phone;
@@ -136,5 +138,35 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses {@code String floor} into a {@code floor}.
+     * Leading and training whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code floor} is invalid.
+     */
+    public static Floor parseFloor(String floor) throws ParseException {
+        requireNonNull(floor);
+        String trimmedFloor = floor.trim();
+        if (!Floor.isValidFloor(trimmedFloor)) {
+            throw new ParseException(Floor.MESSAGE_CONSTRAINTS);
+        }
+        return new Floor(trimmedFloor);
+    }
+
+    /**
+     * Parses {@code String roomNumber} into a {@code roomNumber}.
+     * Leading and training whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code floor} is invalid.
+     */
+    public static RoomNumber parseRoomNumber(String roomNumber) throws ParseException {
+        requireNonNull(roomNumber);
+        String trimmedRoomNumber = roomNumber.trim();
+        if (!Floor.isValidFloor(trimmedRoomNumber)) {
+            throw new ParseException(RoomNumber.MESSAGE_CONSTRAINTS);
+        }
+        return new RoomNumber(trimmedRoomNumber);
     }
 }

--- a/src/main/java/seedu/resireg/model/AddressBook.java
+++ b/src/main/java/seedu/resireg/model/AddressBook.java
@@ -134,7 +134,6 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setRoom(Room target, Room editedRoom) {
         requireNonNull(editedRoom);
-
         rooms.setRoom(target, editedRoom);
     }
 

--- a/src/main/java/seedu/resireg/model/Model.java
+++ b/src/main/java/seedu/resireg/model/Model.java
@@ -81,6 +81,11 @@ public interface Model {
      */
     void setStudent(Student target, Student editedStudent);
 
+    /**
+     * Returns true if a room with the same data as {@code room} exists in the address book.
+     */
+    boolean hasRoom(Room room);
+
     /** Returns an unmodifiable view of the filtered student list */
     ObservableList<Student> getFilteredStudentList();
 

--- a/src/main/java/seedu/resireg/model/ModelManager.java
+++ b/src/main/java/seedu/resireg/model/ModelManager.java
@@ -115,6 +115,12 @@ public class ModelManager implements Model {
         addressBook.setStudent(target, editedStudent);
     }
 
+    @Override
+    public boolean hasRoom(Room room) {
+        requireNonNull(room);
+        return addressBook.hasRoom(room);
+    }
+
     //=========== Filtered Student List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/resireg/model/student/Student.java
+++ b/src/main/java/seedu/resireg/model/student/Student.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.faculty.Faculty;
 import seedu.resireg.model.tag.Tag;
 
@@ -25,6 +26,7 @@ public class Student {
 
     // Data fields
     private final Set<Tag> tags = new HashSet<>();
+    private Room room;
 
     /**
      * Every field must be present and not null.
@@ -67,6 +69,28 @@ public class Student {
         return Collections.unmodifiableSet(tags);
     }
 
+
+    /**
+     * Returns true if a room has been allocated to the student, and false otherwise.
+     */
+    public boolean hasRoom() {
+        return getRoom() != null;
+    }
+
+    /**
+     * Returns the room allocated to the student.
+     */
+    public Room getRoom() {
+        return room;
+    }
+
+    /**
+     * Allocates a room to the student.
+     */
+    public void setRoom(Room room) {
+        this.room = room;
+    }
+
     /**
      * Returns true if both students have the same student identification number (StudentId).
      * This defines a weaker notion of equality between two students, and includes students that have the same ID,
@@ -77,7 +101,8 @@ public class Student {
             return true;
         }
 
-        return otherStudent != null && otherStudent.getStudentId().equals(getStudentId());
+        return otherStudent != null
+                && otherStudent.getStudentId().equals(getStudentId());
     }
 
     /**
@@ -100,13 +125,15 @@ public class Student {
                 && otherStudent.getPhone().equals(getPhone())
                 && otherStudent.getEmail().equals(getEmail())
                 && otherStudent.getFaculty().equals(getFaculty())
-                && otherStudent.getTags().equals(getTags());
+                && otherStudent.getTags().equals(getTags())
+                && otherStudent.hasRoom() == hasRoom()
+                && (!otherStudent.hasRoom() && !hasRoom() || otherStudent.getRoom().equals(getRoom()));
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, faculty, studentId, tags);
+        return Objects.hash(name, phone, email, faculty, studentId, tags, room);
     }
 
     @Override
@@ -123,6 +150,8 @@ public class Student {
                 .append(getFaculty())
                 .append(" Tags: ");
         getTags().forEach(builder::append);
+        builder.append(" Room: ")
+                .append(getRoom());
         return builder.toString();
     }
 

--- a/src/main/java/seedu/resireg/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/resireg/storage/JsonAdaptedStudent.java
@@ -1,17 +1,22 @@
 package seedu.resireg.storage;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import seedu.resireg.commons.exceptions.IllegalValueException;
-import seedu.resireg.model.student.*;
-import seedu.resireg.model.student.faculty.Faculty;
-import seedu.resireg.model.tag.Tag;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.resireg.commons.exceptions.IllegalValueException;
+import seedu.resireg.model.student.Email;
+import seedu.resireg.model.student.Name;
+import seedu.resireg.model.student.Phone;
+import seedu.resireg.model.student.Student;
+import seedu.resireg.model.student.StudentId;
+import seedu.resireg.model.student.faculty.Faculty;
+import seedu.resireg.model.tag.Tag;
 
 /**
  * Jackson-friendly version of {@link Student}.

--- a/src/main/java/seedu/resireg/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/resireg/storage/JsonAdaptedStudent.java
@@ -1,22 +1,17 @@
 package seedu.resireg.storage;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import seedu.resireg.commons.exceptions.IllegalValueException;
+import seedu.resireg.model.student.*;
+import seedu.resireg.model.student.faculty.Faculty;
+import seedu.resireg.model.tag.Tag;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import seedu.resireg.commons.exceptions.IllegalValueException;
-import seedu.resireg.model.student.Email;
-import seedu.resireg.model.student.Name;
-import seedu.resireg.model.student.Phone;
-import seedu.resireg.model.student.Student;
-import seedu.resireg.model.student.StudentId;
-import seedu.resireg.model.student.faculty.Faculty;
-import seedu.resireg.model.tag.Tag;
 
 /**
  * Jackson-friendly version of {@link Student}.
@@ -31,14 +26,17 @@ class JsonAdaptedStudent {
     private final String faculty;
     private final String studentId;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+    private JsonAdaptedRoom room;
 
     /**
      * Constructs a {@code JsonAdaptedStudent} with the given student details.
      */
     @JsonCreator
     public JsonAdaptedStudent(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
-            @JsonProperty("email") String email, @JsonProperty("faculty") String faculty,
-            @JsonProperty("studentId") String studentId, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+                              @JsonProperty("email") String email, @JsonProperty("faculty") String faculty,
+                              @JsonProperty("studentId") String studentId,
+                              @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
+                              @JsonProperty("room") JsonAdaptedRoom room) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -46,6 +44,9 @@ class JsonAdaptedStudent {
         this.studentId = studentId;
         if (tagged != null) {
             this.tagged.addAll(tagged);
+        }
+        if (room != null) {
+            this.room = room;
         }
     }
 
@@ -61,6 +62,9 @@ class JsonAdaptedStudent {
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        if (source.hasRoom()) {
+            room = new JsonAdaptedRoom(source.getRoom());
+        }
     }
 
     /**
@@ -116,7 +120,12 @@ class JsonAdaptedStudent {
         final StudentId modelStudentId = new StudentId(studentId);
 
         final Set<Tag> modelTags = new HashSet<>(studentTags);
-        return new Student(modelName, modelPhone, modelEmail, modelFaculty, modelStudentId, modelTags);
+
+        Student newStudent = new Student(modelName, modelPhone, modelEmail, modelFaculty, modelStudentId, modelTags);
+        if (room != null) {
+            newStudent.setRoom(room.toModelType());
+        }
+        return newStudent;
     }
 
 }

--- a/src/main/java/seedu/resireg/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/resireg/storage/JsonSerializableAddressBook.java
@@ -30,7 +30,8 @@ class JsonSerializableAddressBook {
      * Constructs a {@code JsonSerializableAddressBook} with the given students.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("students") List<JsonAdaptedStudent> students) {
+    public JsonSerializableAddressBook(@JsonProperty("students") List<JsonAdaptedStudent> students,
+                                       @JsonProperty("rooms") List<JsonAdaptedRoom> rooms) {
         this.students.addAll(students);
         this.rooms.addAll(rooms);
     }

--- a/src/main/java/seedu/resireg/ui/StudentCard.java
+++ b/src/main/java/seedu/resireg/ui/StudentCard.java
@@ -41,7 +41,12 @@ public class StudentCard extends UiPart<Region> {
     @FXML
     private Label email;
     @FXML
+    private Label roomNumber;
+    @FXML
+    private Label floor;
+    @FXML
     private FlowPane tags;
+
 
     /**
      * Creates a {@code StudentCard} with the given {@code Student} and index to display.
@@ -55,6 +60,13 @@ public class StudentCard extends UiPart<Region> {
         faculty.setText(student.getFaculty().value);
         studentId.setText(student.getStudentId().value);
         email.setText(student.getEmail().value);
+        if (student.hasRoom()) {
+            floor.setText(student.getRoom().getFloor().value);
+            roomNumber.setText(student.getRoom().getRoomNumber().value);
+        } else {
+            floor.setText("Unassigned");
+            roomNumber.setText("Unassigned");
+        }
         student.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/java/seedu/resireg/ui/StudentCard.java
+++ b/src/main/java/seedu/resireg/ui/StudentCard.java
@@ -64,8 +64,8 @@ public class StudentCard extends UiPart<Region> {
             floor.setText(student.getRoom().getFloor().value);
             roomNumber.setText(student.getRoom().getRoomNumber().value);
         } else {
-            floor.setText("Unassigned");
-            roomNumber.setText("Unassigned");
+            floor.setText("Unallocated");
+            roomNumber.setText("Unallocated");
         }
         student.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/resources/view/StudentListCard.fxml
+++ b/src/main/resources/view/StudentListCard.fxml
@@ -32,6 +32,8 @@
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="faculty" styleClass="cell_small_label" text="\$faculty" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="floor" styleClass="cell_small_label" text="\$floor" />
+      <Label fx:id="roomNumber" styleClass="cell_small_label" text="\$roomNumber" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateStudentAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateStudentAddressBook.json
@@ -12,5 +12,6 @@
     "email": "pauline@example.com",
     "faculty": "FASS",
     "studentId": "E0407881"
-  } ]
+  } ],
+  "rooms": [ ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidStudentAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidStudentAddressBook.json
@@ -5,5 +5,6 @@
     "email": "invalid@email!3e",
     "faculty": "FASS",
     "studentId": "E0407881"
-  } ]
+  } ],
+  "rooms": [ ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalStudentsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalStudentsAddressBook.json
@@ -13,7 +13,12 @@
     "email" : "benson@example.com",
     "faculty": "FASS",
     "studentId": "E0222228",
-    "tagged" : [ "owesMoney", "friends" ]
+    "tagged" : [ "owesMoney", "friends" ],
+    "room": {
+      "floor": "1",
+      "roomNumber": "101",
+      "roomType": "CN"
+    }
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
@@ -49,5 +54,6 @@
     "faculty": "FASS",
     "studentId": "E0111101",
     "tagged" : [ ]
-  } ]
+  } ],
+  "rooms": [ ]
 }

--- a/src/test/java/seedu/resireg/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/AddCommandTest.java
@@ -140,6 +140,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasRoom(Room room) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Student> getFilteredStudentList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/resireg/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/seedu/resireg/storage/JsonAdaptedStudentTest.java
@@ -34,6 +34,7 @@ public class JsonAdaptedStudentTest {
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
+    private static final JsonAdaptedRoom VALID_ROOM = new JsonAdaptedRoom(BENSON.getRoom());
 
     @Test
     public void toModelType_validStudentDetails_returnsStudent() throws Exception {
@@ -45,7 +46,7 @@ public class JsonAdaptedStudentTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_FACULTY,
-                    VALID_STUDENT_ID, VALID_TAGS);
+                    VALID_STUDENT_ID, VALID_TAGS, VALID_ROOM);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -53,7 +54,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedStudent student = new JsonAdaptedStudent(null, VALID_PHONE, VALID_EMAIL, VALID_FACULTY,
-            VALID_STUDENT_ID, VALID_TAGS);
+            VALID_STUDENT_ID, VALID_TAGS, VALID_ROOM);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -62,7 +63,7 @@ public class JsonAdaptedStudentTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_FACULTY,
-                    VALID_STUDENT_ID, VALID_TAGS);
+                    VALID_STUDENT_ID, VALID_TAGS, VALID_ROOM);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -70,7 +71,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, null, VALID_EMAIL, VALID_FACULTY,
-            VALID_STUDENT_ID, VALID_TAGS);
+            VALID_STUDENT_ID, VALID_TAGS, VALID_ROOM);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -79,7 +80,7 @@ public class JsonAdaptedStudentTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_FACULTY,
-                    VALID_STUDENT_ID, VALID_TAGS);
+                    VALID_STUDENT_ID, VALID_TAGS, VALID_ROOM);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -87,7 +88,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, null, VALID_FACULTY,
-            VALID_STUDENT_ID, VALID_TAGS);
+            VALID_STUDENT_ID, VALID_TAGS, VALID_ROOM);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -96,7 +97,7 @@ public class JsonAdaptedStudentTest {
     public void toModelType_invalidFaculty_throwsIllegalValueException() {
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_FACULTY,
-                    VALID_STUDENT_ID, VALID_TAGS);
+                    VALID_STUDENT_ID, VALID_TAGS, VALID_ROOM);
         String expectedMessage = Faculty.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -104,7 +105,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_nullFaculty_throwsIllegalValueException() {
         JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-            VALID_STUDENT_ID, VALID_TAGS);
+            VALID_STUDENT_ID, VALID_TAGS, VALID_ROOM);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Faculty.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -113,7 +114,7 @@ public class JsonAdaptedStudentTest {
     public void toModelType_invalidStudentId_throwsIllegalValueException() {
         JsonAdaptedStudent student =
             new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_FACULTY,
-                INVALID_STUDENT_ID, VALID_TAGS);
+                INVALID_STUDENT_ID, VALID_TAGS, VALID_ROOM);
         String expectedMessage = StudentId.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -121,7 +122,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_nullStudentId_throwsIllegalValueException() {
         JsonAdaptedStudent student = new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_FACULTY,
-            null, VALID_TAGS);
+            null, VALID_TAGS, VALID_ROOM);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, StudentId.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, student::toModelType);
     }
@@ -132,7 +133,7 @@ public class JsonAdaptedStudentTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_FACULTY, VALID_STUDENT_ID,
-                    invalidTags);
+                    invalidTags, VALID_ROOM);
         assertThrows(IllegalValueException.class, student::toModelType);
     }
 

--- a/src/test/java/seedu/resireg/testutil/RoomBuilder.java
+++ b/src/test/java/seedu/resireg/testutil/RoomBuilder.java
@@ -47,7 +47,7 @@ public class RoomBuilder {
     /**
      * Sets the {@code Floor} of the {@code Room} that we are building.
      */
-    public RoomBuilder withName(String floor) {
+    public RoomBuilder withFloor(String floor) {
         this.floor = new Floor(floor);
         return this;
     }

--- a/src/test/java/seedu/resireg/testutil/StudentBuilder.java
+++ b/src/test/java/seedu/resireg/testutil/StudentBuilder.java
@@ -3,6 +3,7 @@ package seedu.resireg.testutil;
 import java.util.HashSet;
 import java.util.Set;
 
+import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.Email;
 import seedu.resireg.model.student.Name;
 import seedu.resireg.model.student.Phone;
@@ -23,13 +24,13 @@ public class StudentBuilder {
     public static final String DEFAULT_FACULTY = "FASS";
     public static final String DEFAULT_STUDENT_ID = "E0407889";
 
-
     private Name name;
     private Phone phone;
     private Email email;
     private Faculty faculty;
     private StudentId studentId;
     private Set<Tag> tags;
+    private Room room;
 
     /**
      * Creates a {@code StudentBuilder} with the default details.
@@ -41,6 +42,7 @@ public class StudentBuilder {
         faculty = new Faculty(DEFAULT_FACULTY);
         studentId = new StudentId(DEFAULT_STUDENT_ID);
         tags = new HashSet<>();
+        room = null;
     }
 
     /**
@@ -103,8 +105,18 @@ public class StudentBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code Room} of the {@code Student} that we are building.
+     */
+    public StudentBuilder withRoom(Room room) {
+        this.room = room;
+        return this;
+    }
+
     public Student build() {
-        return new Student(name, phone, email, faculty, studentId, tags);
+        Student newStudent = new Student(name, phone, email, faculty, studentId, tags);
+        newStudent.setRoom(room);
+        return newStudent;
     }
 
 }

--- a/src/test/java/seedu/resireg/testutil/StudentBuilder.java
+++ b/src/test/java/seedu/resireg/testutil/StudentBuilder.java
@@ -113,6 +113,9 @@ public class StudentBuilder {
         return this;
     }
 
+    /**
+     * Returns a new {@code Student} created.
+     */
     public Student build() {
         Student newStudent = new Student(name, phone, email, faculty, studentId, tags);
         newStudent.setRoom(room);

--- a/src/test/java/seedu/resireg/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/resireg/testutil/TypicalStudents.java
@@ -43,8 +43,8 @@ public class TypicalStudents {
             .withEmail("carl@example.com")
             .withFaculty("FASS")
             .withStudentId("E0111112").build();
-    public static final Student DANIEL = new StudentBuilder().withName("Daniel Meier").
-            withPhone("87652533")
+    public static final Student DANIEL = new StudentBuilder().withName("Daniel Meier")
+            .withPhone("87652533")
             .withFaculty("FASS")
             .withStudentId("E0111113")
             .withEmail("daniel@example.com")

--- a/src/test/java/seedu/resireg/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/resireg/testutil/TypicalStudents.java
@@ -26,28 +26,44 @@ import seedu.resireg.model.student.Student;
 public class TypicalStudents {
 
     public static final Student ALICE = new StudentBuilder().withName("Alice Pauline")
-            .withFaculty("FASS").withStudentId("E0111110")
+            .withFaculty("FASS")
+            .withStudentId("E0111110")
             .withEmail("alice@example.com")
             .withPhone("94351253")
             .withTags("friends").build();
     public static final Student BENSON = new StudentBuilder().withName("Benson Meier")
-            .withFaculty("FASS").withStudentId("E0222228")
-            .withEmail("benson@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").build();
-    public static final Student CARL = new StudentBuilder().withName("Carl Kurz").withPhone("95352563")
+            .withFaculty("FASS")
+            .withStudentId("E0222228")
+            .withEmail("benson@example.com")
+            .withPhone("98765432")
+            .withTags("owesMoney", "friends")
+            .withRoom(new RoomBuilder().withFloor("1").withRoomNumber("101").build()).build();
+    public static final Student CARL = new StudentBuilder().withName("Carl Kurz")
+            .withPhone("95352563")
             .withEmail("carl@example.com")
-            .withFaculty("FASS").withStudentId("E0111112").build();
-    public static final Student DANIEL = new StudentBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withFaculty("FASS").withStudentId("E0111113")
+            .withFaculty("FASS")
+            .withStudentId("E0111112").build();
+    public static final Student DANIEL = new StudentBuilder().withName("Daniel Meier").
+            withPhone("87652533")
+            .withFaculty("FASS")
+            .withStudentId("E0111113")
             .withEmail("daniel@example.com")
             .withTags("friends").build();
-    public static final Student ELLE = new StudentBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("elle@example.com").withFaculty("FASS").withStudentId("E0111114").build();
-    public static final Student FIONA = new StudentBuilder().withName("Fiona Kunz").withPhone("9482427")
+    public static final Student ELLE = new StudentBuilder().withName("Elle Meyer")
+            .withPhone("9482224")
+            .withEmail("elle@example.com")
+            .withFaculty("FASS")
+            .withStudentId("E0111114").build();
+    public static final Student FIONA = new StudentBuilder().withName("Fiona Kunz")
+            .withPhone("9482427")
             .withEmail("fiona@example.com")
-            .withFaculty("FASS").withStudentId("E0111115").build();
-    public static final Student GEORGE = new StudentBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("george@example.com").withFaculty("FASS").withStudentId("E0111101").build();
+            .withFaculty("FASS")
+            .withStudentId("E0111115").build();
+    public static final Student GEORGE = new StudentBuilder().withName("George Best")
+            .withPhone("9482442")
+            .withEmail("george@example.com")
+            .withFaculty("FASS")
+            .withStudentId("E0111101").build();
 
     // Manually added
     public static final Student HOON = new StudentBuilder().withName("Hoon Meier").withPhone("8482424")


### PR DESCRIPTION
This PR adds the functionality increment of the Allocate Command. Allocation of a room to a student is performed by referencing the index of the room and the index of the student in the Address Book, consistent with the Delete Command for deleting a Student from the Address Book. `si/` and `ri/` prefixes thus refers to the student index and room index respectively. Student Card in the user interface now reflects the floor and room number if the student has been allocated a room.

Example usage:
`allocate ri/1 si/1`

Changes made:
* Add `AllocateCommand`, that performs 3 checks on execution:
  * Student referenced exists.
  * Room referenced exists.
  * Student has not already been allocated a room.
* Add `AllocateCommandParser`, that parses student and room indices from `si/` and `ri/` prefixes respectively.
* Add attribute `JsonAdaptedRoom` to `JsonAdaptedStudent`, where 2 cases may occur:
  * If the student has been allocated a room, `JsonAdaptedRoom` will be reflected under the student in `data/addressbook.json`.
  * If the student has not been allocated a room, `null` will be reflected in `data/addressbook.json` instead.
* Add method `withRoom` to `StudentBuilder` in `testutil` and modify `build()` to reflect student's allocated room.
* Modify `StudentCard` in `ui` to reflect `floor` and `roomNumber` if the student has been allocated a room, otherwise shows "Unallocated", and corresponding `StudentListCard.fxml` labels.

To be done:
* Add testing support for `AllocateCommand`, `AllocateCommandParser`, `JsonAdaptedRoom`.
* Add `DeallocateCommand`, `EditAllocateCommand`, including testing support.

As part of #12, #13.