### PR TITLE
Jy/view vacant rooms

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -43,7 +43,7 @@ This section explains the format of commands in this User Guide.
 4. Double-click the file to start the app. The following window should appear within a few seconds - this is the Session Screen, where you can create, open, or delete interview sessions:
 5. Type the command in the command box and press <kbd>Enter</kbd> to execute it. e.g. typing `help` and pressing Enter will open this user guide.
 6. Some example commands you can try:
-    -  `list rooms`: lists all rooms that are vacant.
+    -  `rooms --vacant`: lists all rooms that are vacant.
     - `allocate A0123456X 08-108`: allocate a student with the student ID A0123456X to room number 08-108.
     - `exit`: exits the app.
 8. Refer to “Features” for details of all the commands.
@@ -55,7 +55,7 @@ This section explains the format of commands in this User Guide.
 
 #### 1. Viewing a list of all vacant rooms
 
-Before assigning a room to a student at the start of the semester, you can view a list of all vacant rooms using the `list rooms` command.
+Before assigning a room to a student at the start of the semester, you can view a list of all vacant rooms using the `rooms --vacant` command.
 
 ##### Command
 ```
@@ -156,11 +156,11 @@ The room allocations for all students in the residential college can be viewed t
 
 ##### Command
 ```
-rooms
+rooms --vacant
 ```
 ##### Execution Example
 ```
-> rooms
+> rooms --vacant
 ```
 *Action*: views the room allocations for all students
 
@@ -284,7 +284,7 @@ help
 ```
 ##### Execution Example
 ```
-> list rooms - views a list of vacant rooms
+> rooms --vacant - views a list of vacant rooms
 > ...
 ```
 

--- a/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
@@ -73,6 +73,14 @@ public class AllocateCommand extends Command {
         }
 
         studentToAllocate.setRoom(roomToAllocate);
+        roomToAllocate.setStudent(studentToAllocate);
+
+        model.setStudent(studentToAllocate, studentToAllocate);
+        model.setRoom(roomToAllocate, roomToAllocate);
+
+        model.updateFilteredStudentList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredRoomList(Model.PREDICATE_SHOW_ALL_ROOMS);
+
         return new CommandResult(String.format(MESSAGE_SUCCESS, studentToAllocate, roomToAllocate));
     }
 

--- a/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
@@ -20,10 +20,10 @@ import seedu.resireg.model.student.Student;
 public class AllocateCommand extends Command {
 
     public static final String COMMAND_WORD = "allocate";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Allocates a student to a room. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Allocates a student to a room. \n"
             + "Parameters: "
             + PREFIX_STUDENT_INDEX + "STUDENT INDEX "
-            + PREFIX_ROOM_INDEX + "ROOM INDEX"
+            + PREFIX_ROOM_INDEX + "ROOM INDEX\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_STUDENT_INDEX + "1 "
             + PREFIX_ROOM_INDEX + "1";

--- a/src/main/java/seedu/resireg/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/resireg/logic/commands/CommandResult.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import seedu.resireg.ui.MainWindow;
+
 /**
  * Represents the result of a command execution.
  */
@@ -68,4 +70,6 @@ public class CommandResult {
         return Objects.hash(feedbackToUser, showHelp, exit);
     }
 
+    public void displayResult(MainWindow mainWindow) {
+    }
 }

--- a/src/main/java/seedu/resireg/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ListCommand.java
@@ -19,6 +19,6 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredStudentList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new ToggleCommandResult(MESSAGE_SUCCESS, TabView.STUDENTS);
     }
 }

--- a/src/main/java/seedu/resireg/logic/commands/ListRoomCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ListRoomCommand.java
@@ -1,7 +1,6 @@
 package seedu.resireg.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.resireg.model.Model.PREDICATE_SHOW_ALL_ROOMS;
 
 import seedu.resireg.model.Model;
 
@@ -10,14 +9,32 @@ import seedu.resireg.model.Model;
  */
 public class ListRoomCommand extends Command {
     public static final String COMMAND_WORD = "rooms";
+    public static final String COMMAND_VACANT_FLAG = "--vacant";
 
     public static final String MESSAGE_SUCCESS = "Listed all rooms";
+    public static final String MESSAGE_VACANT_SUCCESS = "Listed all vacant rooms";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all rooms within the system. If the "
+            + COMMAND_VACANT_FLAG
+            + " parameter is specified, find only rooms that are vacant, meaning no students are assigned to them.\n"
+            + "Parameters: [" + COMMAND_VACANT_FLAG + "]...\n"
+            + "Example: " + COMMAND_WORD;
 
+    private final boolean shouldDisplayOnlyVacant;
+
+    public ListRoomCommand(boolean shouldDisplayOnlyVacant) {
+        this.shouldDisplayOnlyVacant = shouldDisplayOnlyVacant;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredRoomList(PREDICATE_SHOW_ALL_ROOMS);
-        return new CommandResult(MESSAGE_SUCCESS);
+
+        if (shouldDisplayOnlyVacant) {
+            model.updateFilteredRoomList(room -> !room.hasStudent());
+            return new ToggleCommandResult(MESSAGE_VACANT_SUCCESS, TabView.ROOMS);
+        } else {
+            model.updateFilteredRoomList(Model.PREDICATE_SHOW_ALL_ROOMS);
+            return new ToggleCommandResult(MESSAGE_SUCCESS, TabView.ROOMS);
+        }
     }
 }

--- a/src/main/java/seedu/resireg/logic/commands/TabView.java
+++ b/src/main/java/seedu/resireg/logic/commands/TabView.java
@@ -1,0 +1,9 @@
+package seedu.resireg.logic.commands;
+
+/**
+ * Enum representing the information ResiReg is supposed to display in the Results panel.
+ */
+public enum TabView {
+    STUDENTS,
+    ROOMS
+}

--- a/src/main/java/seedu/resireg/logic/commands/ToggleCommandResult.java
+++ b/src/main/java/seedu/resireg/logic/commands/ToggleCommandResult.java
@@ -1,0 +1,32 @@
+package seedu.resireg.logic.commands;
+
+import seedu.resireg.ui.MainWindow;
+
+// @@author CornCobs-reused
+// Reused from
+// https://github.com/AY1920S2-CS2103-W15-2/
+// with minor modifications
+public class ToggleCommandResult extends CommandResult {
+    private final TabView tabView;
+
+    /**
+     * Constructs a {@code ToggleCommandResult} with the specified {@code feedbackToUser},
+     * that will toggle the UI to the given TabView.
+     */
+    public ToggleCommandResult(String feedbackToUser, TabView tabView) {
+        super(feedbackToUser);
+        this.tabView = tabView;
+    }
+
+    @Override
+    public void displayResult(MainWindow mainWindow) {
+        mainWindow.handleToggle(tabView);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return super.equals(other)
+                && other instanceof ToggleCommandResult
+                && tabView == ((ToggleCommandResult) other).tabView;
+    }
+}

--- a/src/main/java/seedu/resireg/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/AddressBookParser.java
@@ -65,7 +65,7 @@ public class AddressBookParser {
             return new ListCommand();
 
         case ListRoomCommand.COMMAND_WORD:
-            return new ListRoomCommand();
+            return new ListRoomCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/resireg/logic/parser/ListRoomCommandParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/ListRoomCommandParser.java
@@ -1,0 +1,21 @@
+package seedu.resireg.logic.parser;
+
+import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.resireg.logic.commands.ListRoomCommand;
+import seedu.resireg.logic.parser.exceptions.ParseException;
+
+public class ListRoomCommandParser implements Parser<ListRoomCommand> {
+    @Override
+    public ListRoomCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.strip();
+
+        if (trimmedArgs.isEmpty()) {
+            return new ListRoomCommand(false);
+        } else if (trimmedArgs.equalsIgnoreCase(ListRoomCommand.COMMAND_VACANT_FLAG)) {
+            return new ListRoomCommand(true);
+        }
+        throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListRoomCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/main/java/seedu/resireg/model/Model.java
+++ b/src/main/java/seedu/resireg/model/Model.java
@@ -82,6 +82,14 @@ public interface Model {
     void setStudent(Student target, Student editedStudent);
 
     /**
+     * Replaces the given room {@code target} with {@code editedRoom}.
+     * {@code target} must exist in the address book.
+     * The room identity of {@code editedStudent} must not be the same as another existing room
+     * in the address book.
+     */
+    void setRoom(Room target, Room editedRoom);
+
+    /**
      * Returns true if a room with the same data as {@code room} exists in the address book.
      */
     boolean hasRoom(Room room);

--- a/src/main/java/seedu/resireg/model/ModelManager.java
+++ b/src/main/java/seedu/resireg/model/ModelManager.java
@@ -116,6 +116,13 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void setRoom(Room target, Room editedRoom) {
+        requireAllNonNull(target, editedRoom);
+
+        addressBook.setRoom(target, editedRoom);
+    }
+
+    @Override
     public boolean hasRoom(Room room) {
         requireNonNull(room);
         return addressBook.hasRoom(room);

--- a/src/main/java/seedu/resireg/model/room/Room.java
+++ b/src/main/java/seedu/resireg/model/room/Room.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import seedu.resireg.model.room.roomtype.RoomType;
+import seedu.resireg.model.student.Student;
 import seedu.resireg.model.tag.Tag;
 
 /**
@@ -23,16 +24,19 @@ public class Room {
 
     // Data fields
     private final Set<Tag> tags = new HashSet<>();
+    private Student student;
 
     /**
      * Every field must be present and not null.
      */
-    public Room (Floor floor, RoomNumber number, RoomType roomType, Set<Tag> tags) {
+    public Room(Floor floor, RoomNumber number, RoomType roomType,
+                Set<Tag> tags) {
         requireAllNonNull(floor, number, roomType, tags);
         this.floor = floor;
         this.number = number;
         this.roomType = roomType;
         this.tags.addAll(tags);
+        this.student = null; // defensive check
     }
 
     public Floor getFloor() {
@@ -47,6 +51,21 @@ public class Room {
         return roomType;
     }
 
+    public Student getStudent() {
+        return student;
+    }
+
+    public void setStudent(Student student) {
+        if (student == null) {
+            return;
+        }
+
+        if (student.hasRoom() && !student.getRoom().isSameRoom(this)) {
+            student.unsetRoom();
+        }
+        this.student = student;
+    }
+
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
@@ -56,17 +75,31 @@ public class Room {
     }
 
     /**
+     * @return true if a Student has been allocated to this room, otherwise false
+     */
+    public boolean hasStudent() {
+        return getStudent() != null;
+    }
+
+    /**
+     * Deallocates the Student currently assigned to this Room.
+     */
+    public void unsetStudent() {
+        student = null;
+    }
+
+    /**
      * Returns true if both rooms have the same floor and room numbers.
-     * This defines a weaker notion of equality between two rooms, and includes rooms that have the same ID,
-     * but different fields (roomtype).
+     * This defines a weaker notion of equality between two rooms, and includes
+     * rooms that have the same ID, but different fields (roomtype).
      */
     public boolean isSameRoom(Room otherRoom) {
         if (otherRoom == this) {
             return true;
         }
 
-        return otherRoom != null && otherRoom.getFloor().equals(getFloor())
-                && otherRoom.getRoomNumber().equals(getRoomNumber());
+        return otherRoom != null && otherRoom.getFloor().equals(getFloor()) &&
+                otherRoom.getRoomNumber().equals(getRoomNumber());
     }
 
     /**
@@ -82,16 +115,19 @@ public class Room {
             return false;
         }
 
-        seedu.resireg.model.room.Room otherRoom = (seedu.resireg.model.room.Room) other;
-        return otherRoom.getFloor().equals(getFloor())
-                && otherRoom.getRoomNumber().equals(getRoomNumber())
-                && otherRoom.getRoomType().equals(getRoomType())
-                && otherRoom.getTags().equals(getTags());
+        seedu.resireg.model.room.Room otherRoom =
+                (seedu.resireg.model.room.Room) other;
+        return otherRoom.getFloor().equals(getFloor()) &&
+                otherRoom.getRoomNumber().equals(getRoomNumber()) &&
+                otherRoom.getRoomType().equals(getRoomType()) &&
+                otherRoom.getTags().equals(getTags()) &&
+                otherRoom.getStudent().equals(getStudent());
     }
 
     @Override
     public int hashCode() {
-        // use this method for custom fields hashing instead of implementing your own
+        // use this method for custom fields hashing instead of implementing your
+        // own
         return Objects.hash(floor, number, roomType, tags);
     }
 
@@ -104,10 +140,10 @@ public class Room {
                 .append(getRoomNumber())
                 .append(" Type: ")
                 .append(getRoomType())
+                .append(" Student : ")
+                .append(getStudent())
                 .append(" Tags: ");
         getTags().forEach(builder::append);
         return builder.toString();
     }
-
 }
-

--- a/src/main/java/seedu/resireg/model/room/Room.java
+++ b/src/main/java/seedu/resireg/model/room/Room.java
@@ -98,8 +98,8 @@ public class Room {
             return true;
         }
 
-        return otherRoom != null && otherRoom.getFloor().equals(getFloor()) &&
-                otherRoom.getRoomNumber().equals(getRoomNumber());
+        return otherRoom != null && otherRoom.getFloor().equals(getFloor())
+                && otherRoom.getRoomNumber().equals(getRoomNumber());
     }
 
     /**
@@ -117,11 +117,11 @@ public class Room {
 
         seedu.resireg.model.room.Room otherRoom =
                 (seedu.resireg.model.room.Room) other;
-        return otherRoom.getFloor().equals(getFloor()) &&
-                otherRoom.getRoomNumber().equals(getRoomNumber()) &&
-                otherRoom.getRoomType().equals(getRoomType()) &&
-                otherRoom.getTags().equals(getTags()) &&
-                otherRoom.getStudent().equals(getStudent());
+        return otherRoom.getFloor().equals(getFloor())
+                && otherRoom.getRoomNumber().equals(getRoomNumber())
+                && otherRoom.getRoomType().equals(getRoomType())
+                && otherRoom.getTags().equals(getTags())
+                && otherRoom.getStudent().equals(getStudent());
     }
 
     @Override

--- a/src/main/java/seedu/resireg/model/room/Room.java
+++ b/src/main/java/seedu/resireg/model/room/Room.java
@@ -121,7 +121,7 @@ public class Room {
                 && otherRoom.getRoomNumber().equals(getRoomNumber())
                 && otherRoom.getRoomType().equals(getRoomType())
                 && otherRoom.getTags().equals(getTags())
-                && otherRoom.getStudent().equals(getStudent());
+                && Objects.equals(otherRoom.getStudent(), getStudent());
     }
 
     @Override

--- a/src/main/java/seedu/resireg/model/room/Room.java
+++ b/src/main/java/seedu/resireg/model/room/Room.java
@@ -140,8 +140,6 @@ public class Room {
                 .append(getRoomNumber())
                 .append(" Type: ")
                 .append(getRoomType())
-                .append(" Student : ")
-                .append(getStudent())
                 .append(" Tags: ");
         getTags().forEach(builder::append);
         return builder.toString();

--- a/src/main/java/seedu/resireg/model/student/Student.java
+++ b/src/main/java/seedu/resireg/model/student/Student.java
@@ -141,8 +141,7 @@ public class Student {
                 && otherStudent.getEmail().equals(getEmail())
                 && otherStudent.getFaculty().equals(getFaculty())
                 && otherStudent.getTags().equals(getTags())
-                && otherStudent.hasRoom() == hasRoom()
-                && (!otherStudent.hasRoom() && !hasRoom() || otherStudent.getRoom().equals(getRoom()));
+                && Objects.equals(otherStudent.getRoom(), getRoom());
     }
 
     @Override

--- a/src/main/java/seedu/resireg/model/student/Student.java
+++ b/src/main/java/seedu/resireg/model/student/Student.java
@@ -164,8 +164,6 @@ public class Student {
                 .append(getFaculty())
                 .append(" Tags: ");
         getTags().forEach(builder::append);
-        builder.append(" Room: ")
-                .append(getRoom());
         return builder.toString();
     }
 

--- a/src/main/java/seedu/resireg/model/student/Student.java
+++ b/src/main/java/seedu/resireg/model/student/Student.java
@@ -39,6 +39,7 @@ public class Student {
         this.faculty = faculty;
         this.studentId = studentId;
         this.tags.addAll(tags);
+        this.room = null; // defensive check
     }
 
     public Name getName() {
@@ -88,7 +89,21 @@ public class Student {
      * Allocates a room to the student.
      */
     public void setRoom(Room room) {
+        if (room == null) {
+            return;
+        }
+
+        if (room.hasStudent() && !room.getStudent().isSameStudent(this)) {
+            room.unsetStudent();
+        }
         this.room = room;
+    }
+
+    /**
+     * Deallocates the Student from their current Room.
+     */
+    public void unsetRoom() {
+        room = null;
     }
 
     /**

--- a/src/main/java/seedu/resireg/storage/JsonAdaptedRoomStudent.java
+++ b/src/main/java/seedu/resireg/storage/JsonAdaptedRoomStudent.java
@@ -1,0 +1,121 @@
+package seedu.resireg.storage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.resireg.commons.exceptions.IllegalValueException;
+import seedu.resireg.model.student.Email;
+import seedu.resireg.model.student.Name;
+import seedu.resireg.model.student.Phone;
+import seedu.resireg.model.student.Student;
+import seedu.resireg.model.student.StudentId;
+import seedu.resireg.model.student.faculty.Faculty;
+import seedu.resireg.model.tag.Tag;
+
+public class JsonAdaptedRoomStudent {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Student's %s field is missing!";
+
+    private final String name;
+    private final String phone;
+    private final String email;
+    private final String faculty;
+    private final String studentId;
+    private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonAdaptedStudent} with the given student details.
+     */
+    @JsonCreator
+    public JsonAdaptedRoomStudent(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
+                              @JsonProperty("email") String email, @JsonProperty("faculty") String faculty,
+                              @JsonProperty("studentId") String studentId,
+                              @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+        this.faculty = faculty;
+        this.studentId = studentId;
+        if (tagged != null) {
+            this.tagged.addAll(tagged);
+        }
+    }
+
+    /**
+     * Converts a given {@code Student} into this class for Jackson use.
+     */
+    public JsonAdaptedRoomStudent(Student source) {
+        name = source.getName().fullName;
+        phone = source.getPhone().value;
+        email = source.getEmail().value;
+        faculty = source.getFaculty().value;
+        studentId = source.getStudentId().value;
+        tagged.addAll(source.getTags().stream()
+                .map(JsonAdaptedTag::new)
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted student object into the model's {@code Student} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted student.
+     */
+    public Student toModelType() throws IllegalValueException {
+        final List<Tag> studentTags = new ArrayList<>();
+        for (JsonAdaptedTag tag : tagged) {
+            studentTags.add(tag.toModelType());
+        }
+
+        if (name == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
+        if (!Name.isValidName(name)) {
+            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
+        }
+        final Name modelName = new Name(name);
+
+        if (phone == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName()));
+        }
+        if (!Phone.isValidPhone(phone)) {
+            throw new IllegalValueException(Phone.MESSAGE_CONSTRAINTS);
+        }
+        final Phone modelPhone = new Phone(phone);
+
+        if (email == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName()));
+        }
+        if (!Email.isValidEmail(email)) {
+            throw new IllegalValueException(Email.MESSAGE_CONSTRAINTS);
+        }
+        final Email modelEmail = new Email(email);
+
+        if (faculty == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Faculty.class.getSimpleName()));
+        }
+        if (!Faculty.isValidFaculty(faculty)) {
+            throw new IllegalValueException(Faculty.MESSAGE_CONSTRAINTS);
+        }
+        final Faculty modelFaculty = new Faculty(faculty);
+
+        if (studentId == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    StudentId.class.getSimpleName()));
+        }
+        if (!StudentId.isValidStudentId(studentId)) {
+            throw new IllegalValueException(StudentId.MESSAGE_CONSTRAINTS);
+        }
+        final StudentId modelStudentId = new StudentId(studentId);
+
+        final Set<Tag> modelTags = new HashSet<>(studentTags);
+
+        return new Student(modelName, modelPhone, modelEmail, modelFaculty, modelStudentId, modelTags);
+    }
+
+}

--- a/src/main/java/seedu/resireg/storage/JsonAdaptedStudentRoom.java
+++ b/src/main/java/seedu/resireg/storage/JsonAdaptedStudentRoom.java
@@ -16,10 +16,7 @@ import seedu.resireg.model.room.RoomNumber;
 import seedu.resireg.model.room.roomtype.RoomType;
 import seedu.resireg.model.tag.Tag;
 
-/**
- * Jackson-friendly version of {@link Room}.
- */
-class JsonAdaptedRoom {
+public class JsonAdaptedStudentRoom {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Room's %s field is missing!";
 
@@ -27,40 +24,32 @@ class JsonAdaptedRoom {
     private final String roomNumber;
     private final String roomType;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
-    private JsonAdaptedRoomStudent student;
 
     /**
      * Constructs a {@code JsonAdaptedRoom} with the given room details.
      */
     @JsonCreator
-    public JsonAdaptedRoom(@JsonProperty("floor") String floor, @JsonProperty("roomNumber") String number,
-                           @JsonProperty("roomType") String roomType,
-                           @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
-                           @JsonProperty("student") JsonAdaptedRoomStudent student) {
+    public JsonAdaptedStudentRoom(@JsonProperty("floor") String floor, @JsonProperty("roomNumber") String number,
+                                  @JsonProperty("roomType") String roomType,
+                                  @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.floor = floor;
         this.roomNumber = number;
         this.roomType = roomType;
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
-        if (student != null) {
-            this.student = student;
-        }
     }
 
     /**
      * Converts a given {@code Room} into this class for Jackson use.
      */
-    public JsonAdaptedRoom(Room source) {
+    public JsonAdaptedStudentRoom(Room source) {
         floor = source.getFloor().value;
         roomNumber = source.getRoomNumber().value;
         roomType = source.getRoomType().name;
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
-        if (source.hasStudent()) {
-            this.student = new JsonAdaptedRoomStudent(source.getStudent());
-        }
     }
 
     /**
@@ -100,13 +89,7 @@ class JsonAdaptedRoom {
         final RoomType modelRoomType = new RoomType(roomType);
 
         final Set<Tag> modelTags = new HashSet<>(roomTags);
-
-        Room newRoom = new Room(modelFloor, modelNumber, modelRoomType, modelTags);
-        if (student != null) {
-            newRoom.setStudent(student.toModelType());
-        }
-        return newRoom;
+        return new Room(modelFloor, modelNumber, modelRoomType, modelTags);
     }
 
 }
-

--- a/src/main/java/seedu/resireg/ui/MainWindow.java
+++ b/src/main/java/seedu/resireg/ui/MainWindow.java
@@ -5,6 +5,8 @@ import java.util.logging.Logger;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
@@ -14,6 +16,7 @@ import seedu.resireg.commons.core.GuiSettings;
 import seedu.resireg.commons.core.LogsCenter;
 import seedu.resireg.logic.Logic;
 import seedu.resireg.logic.commands.CommandResult;
+import seedu.resireg.logic.commands.TabView;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.logic.parser.exceptions.ParseException;
 
@@ -32,6 +35,7 @@ public class MainWindow extends UiPart<Stage> {
 
     // Independent Ui parts residing in this Ui container
     private StudentListPanel studentListPanel;
+    private RoomListPanel roomListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
@@ -45,10 +49,22 @@ public class MainWindow extends UiPart<Stage> {
     private StackPane studentListPanelPlaceholder;
 
     @FXML
+    private StackPane roomListPanelPlaceholder;
+
+    @FXML
     private StackPane resultDisplayPlaceholder;
 
     @FXML
     private StackPane statusbarPlaceholder;
+
+    @FXML
+    private TabPane tabPane;
+
+    @FXML
+    private Tab studentsTab;
+
+    @FXML
+    private Tab roomsTab;
 
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
@@ -78,6 +94,7 @@ public class MainWindow extends UiPart<Stage> {
 
     /**
      * Sets the accelerator of a MenuItem.
+     *
      * @param keyCombination the KeyCombination value of the accelerator
      */
     private void setAccelerator(MenuItem menuItem, KeyCombination keyCombination) {
@@ -112,7 +129,11 @@ public class MainWindow extends UiPart<Stage> {
     void fillInnerParts() {
         studentListPanel = new StudentListPanel(logic.getFilteredStudentList());
         studentListPanelPlaceholder.getChildren()
-            .add(studentListPanel.getRoot());
+                .add(studentListPanel.getRoot());
+
+        roomListPanel = new RoomListPanel(logic.getFilteredRoomList());
+        roomListPanelPlaceholder.getChildren()
+                .add(roomListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -148,6 +169,27 @@ public class MainWindow extends UiPart<Stage> {
         }
     }
 
+    /**
+     * Sets what is displayed in the listPanelStackPane based on the toggle.
+     *
+     * @param toggleView enum representing what should be displayed
+     */
+    public void handleToggle(TabView toggleView) {
+        if (toggleView == TabView.ROOMS) {
+            showRoomsPanel();
+        } else {
+            showStudentPanel();
+        }
+    }
+
+    private void showStudentPanel() {
+        tabPane.getSelectionModel().select(studentsTab);
+    }
+
+    private void showRoomsPanel() {
+        tabPane.getSelectionModel().select(roomsTab);
+    }
+
     void show() {
         primaryStage.show();
     }
@@ -178,6 +220,8 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandText, commandResult.getFeedbackToUser());
+
+            commandResult.displayResult(this);
 
             if (commandResult.isShowHelp()) {
                 handleHelp();

--- a/src/main/java/seedu/resireg/ui/RoomCard.java
+++ b/src/main/java/seedu/resireg/ui/RoomCard.java
@@ -1,0 +1,79 @@
+package seedu.resireg.ui;
+
+import java.util.Comparator;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.resireg.model.room.Room;
+
+public class RoomCard extends UiPart<Region> {
+    private static final String FXML = "RoomListCard.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final Room room;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label id;
+    @FXML
+    private Label roomLabel;
+    @FXML
+    private Label roomType;
+    @FXML
+    private Label studentId;
+    @FXML
+    private Label studentName;
+    @FXML
+    private FlowPane tags;
+
+
+    /**
+     * Creates a {@code RoomCard} with the given {@code Room} and index to display.
+     */
+    public RoomCard(Room room, int displayedIndex) {
+        super(FXML);
+        this.room = room;
+        id.setText(displayedIndex + ". ");
+        roomLabel.setText(room.getFloor() + "-" + room.getRoomNumber());
+        roomType.setText(room.getRoomType().toString());
+        if (room.hasStudent()) {
+            studentId.setText(room.getStudent().getStudentId().value);
+            studentName.setText(room.getStudent().getName().fullName);
+        } else {
+            studentId.setText("Unallocated");
+            studentName.setText("Unallocated");
+        }
+        room.getTags().stream()
+                .sorted(Comparator.comparing(tag -> tag.tagName))
+                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RoomCard)) {
+            return false;
+        }
+
+        // state check
+        RoomCard card = (RoomCard) other;
+        return id.getText().equals(card.id.getText())
+                && room.equals(card.room);
+    }
+}

--- a/src/main/java/seedu/resireg/ui/RoomListPanel.java
+++ b/src/main/java/seedu/resireg/ui/RoomListPanel.java
@@ -1,0 +1,46 @@
+package seedu.resireg.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.resireg.commons.core.LogsCenter;
+import seedu.resireg.model.room.Room;
+
+public class RoomListPanel extends UiPart<Region> {
+    private static final String FXML = "RoomListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(RoomListPanel.class);
+
+    @FXML
+    private ListView<Room> roomListView;
+
+    /**
+     * Creates a {@code RoomListPanel} with the given {@code ObservableList}.
+     */
+    public RoomListPanel(ObservableList<Room> roomList) {
+        super(FXML);
+        roomListView.setItems(roomList);
+        roomListView.setCellFactory(listView -> new RoomListPanel.RoomListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Room} using a {@code RoomCard}.
+     */
+    class RoomListViewCell extends ListCell<Room> {
+        @Override
+        protected void updateItem(Room room, boolean empty) {
+            super.updateItem(room, empty);
+
+            if (empty || room == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new RoomCard(room, getIndex() + 1).getRoot());
+            }
+        }
+    }
+
+}

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -5,6 +5,8 @@
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
+<?import javafx.scene.control.Tab?>
+<?import javafx.scene.control.TabPane?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
@@ -13,7 +15,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.Scene?>
 <?import javafx.stage.Stage?>
-<fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
+<fx:root xmlns:fx="http://javafx.com/fxml/1" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8"
          title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
     <icons>
         <Image url="@/images/address_book_32.png"/>
@@ -68,16 +70,35 @@
                     </StackPane>
                 </VBox>
 
-                <VBox fx:id="studentList"
-                      VBox.vgrow="ALWAYS"
-                      styleClass="pane-with-border"
-                      minWidth="340" prefWidth="340"
-                      GridPane.columnIndex="1" GridPane.rowIndex="1" GridPane.rowSpan="2">
-                    <padding>
-                        <Insets top="10" right="10" bottom="10" left="10"/>
-                    </padding>
-                    <StackPane fx:id="studentListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-                </VBox>
+                <TabPane fx:id="tabPane"
+                         tabClosingPolicy="UNAVAILABLE"
+                         GridPane.columnIndex="1" GridPane.rowIndex="1" GridPane.rowSpan="2">
+
+                    <!-- Students tab -->
+                    <Tab fx:id="studentsTab" text="Students">
+                        <VBox fx:id="studentList"
+                              VBox.vgrow="ALWAYS"
+                              styleClass="pane-with-border"
+                              minWidth="340" prefWidth="340">
+                            <padding>
+                                <Insets top="10" right="10" bottom="10" left="10"/>
+                            </padding>
+                            <StackPane fx:id="studentListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                        </VBox>
+                    </Tab>
+                    <!-- Rooms tab -->
+                    <Tab fx:id="roomsTab" text="Rooms">
+                        <VBox fx:id="roomList"
+                              VBox.vgrow="ALWAYS"
+                              styleClass="pane-with-border"
+                              minWidth="340" prefWidth="340">
+                            <padding>
+                                <Insets top="10" right="10" bottom="10" left="10"/>
+                            </padding>
+                            <StackPane fx:id="roomListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                        </VBox>
+                    </Tab>
+                </TabPane>
 
                 <StackPane fx:id="statusbarPlaceholder"
                            VBox.vgrow="NEVER"

--- a/src/main/resources/view/RoomListCard.fxml
+++ b/src/main/resources/view/RoomListCard.fxml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+<HBox xmlns:fx="http://javafx.com/fxml/1" id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8">
+    <GridPane HBox.hgrow="ALWAYS">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150"/>
+        </columnConstraints>
+        <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+            <padding>
+                <Insets top="5" right="5" bottom="5" left="15"/>
+            </padding>
+            <HBox spacing="5" alignment="CENTER_LEFT">
+                <Label fx:id="id" styleClass="cell_big_label">
+                    <minWidth>
+                        <!-- Ensures that the label text is never truncated -->
+                        <Region fx:constant="USE_PREF_SIZE"/>
+                    </minWidth>
+                </Label>
+                <Label fx:id="roomLabel" text="\$roomLabel" styleClass="cell_big_label"/>
+            </HBox>
+            <FlowPane fx:id="tags"/>
+            <Label fx:id="roomType" styleClass="cell_small_label" text="\$roomType"/>
+            <Label fx:id="studentName" styleClass="cell_small_label" text="\$studentName"/>
+            <Label fx:id="studentId" styleClass="cell_small_label" text="\$studentId"/>
+        </VBox>
+    </GridPane>
+</HBox>

--- a/src/main/resources/view/RoomListPanel.fxml
+++ b/src/main/resources/view/RoomListPanel.fxml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+<VBox xmlns:fx="http://javafx.com/fxml/1" xmlns="http://javafx.com/javafx/8">
+    <ListView fx:id="roomListView" VBox.vgrow="ALWAYS"/>
+</VBox>

--- a/src/test/java/seedu/resireg/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/AddCommandTest.java
@@ -140,6 +140,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void setRoom(Room target, Room editedRoom) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasRoom(Room room) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/resireg/testutil/RoomBuilder.java
+++ b/src/test/java/seedu/resireg/testutil/RoomBuilder.java
@@ -7,6 +7,7 @@ import seedu.resireg.model.room.Floor;
 import seedu.resireg.model.room.Room;
 import seedu.resireg.model.room.RoomNumber;
 import seedu.resireg.model.room.roomtype.RoomType;
+import seedu.resireg.model.student.Student;
 import seedu.resireg.model.tag.Tag;
 import seedu.resireg.model.util.SampleDataUtil;
 
@@ -22,6 +23,7 @@ public class RoomBuilder {
     private Floor floor;
     private RoomNumber roomNumber;
     private RoomType roomType;
+    private Student student;
     private Set<Tag> tags;
 
     /**
@@ -73,6 +75,14 @@ public class RoomBuilder {
      */
     public RoomBuilder withRoomNumber(String number) {
         this.roomNumber = new RoomNumber(number);
+        return this;
+    }
+
+    /**
+     * Sets the {@code RoomNumber} of the {@code Room} that we are building.
+     */
+    public RoomBuilder withStudent(Student student) {
+        this.student = student;
         return this;
     }
 


### PR DESCRIPTION
Closes #10 

This PR adds the ability to view vacant rooms with a flag `--vacant`.

While working on this, I identified several issues.
1. The tests were not compiling. I have resolved that.
2. One of the tests, while passing, makes some assumptions about the equality of the objects involved. I haven't added another check for that. (In fact, I haven't added any tests)

Additionally, we never had a UI for displaying rooms, although the models were mostly working underneath. I've added a tabbed based UI for them. Depending on the command, it should navigate to the correct tab. For example, `rooms` should automatically switch to the Rooms tab.

![image](https://user-images.githubusercontent.com/22059033/95735722-c8a90280-0cb7-11eb-936d-ce2a19bb9b97.png)


~~I'm currently fixing a bug where the Rooms are not saved. I will unmark this as a draft when that is done.~~
EDIT: I have come up with code that works. However, it involves creating additional classes for serialization, which I don't find ideal (see cbd0b8d). I'd be happy to accept suggestions, although I doubt I can implement it before v1.2 closes.