### PR TITLE
Add tests for Room model

### DIFF
--- a/src/test/java/seedu/resireg/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/resireg/logic/commands/CommandTestUtil.java
@@ -40,6 +40,15 @@ public class CommandTestUtil {
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
+    public static final String VALID_FLOOR_A = "21";
+    public static final String VALID_FLOOR_B = "7";
+    public static final String VALID_ROOM_NUMBER_A = "120";
+    public static final String VALID_ROOM_NUMBER_B = "105";
+    public static final String VALID_ROOM_TYPE_A = "CA";
+    public static final String VALID_ROOM_TYPE_B = "NA";
+    public static final String VALID_TAG_RENOVATED = "renovated";
+    public static final String VALID_TAG_DAMAGED = "damaged";
+
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;

--- a/src/test/java/seedu/resireg/model/room/RoomTest.java
+++ b/src/test/java/seedu/resireg/model/room/RoomTest.java
@@ -1,26 +1,84 @@
 package seedu.resireg.model.room;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_FLOOR_B;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ROOM_NUMBER_B;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ROOM_TYPE_B;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_TAG_DAMAGED;
+import static seedu.resireg.testutil.Assert.assertThrows;
+import static seedu.resireg.testutil.TypicalRooms.ROOM_A;
+import static seedu.resireg.testutil.TypicalRooms.ROOM_B;
+
 import org.junit.jupiter.api.Test;
 
-class RoomTest {
+import seedu.resireg.testutil.RoomBuilder;
+
+public class RoomTest {
 
     @Test
-    void getFloor() {
+    public void asObservableList_modifyList_throwsUnsupportedOperationException() {
+        Room room = new RoomBuilder().build();
+        assertThrows(UnsupportedOperationException.class, () -> room.getTags().remove(0));
     }
 
     @Test
-    void getRoomNumber() {
+    public void isSameRoom() {
+        // same object, returns true
+        assertTrue(ROOM_A.isSameRoom(ROOM_A));
+
+        // null, returns false
+        assertFalse(ROOM_A.isSameRoom(null));
+
+        // different room type, same floor and room number -> returns true
+        Room editedRoomA = new RoomBuilder(ROOM_A).withRoomType(VALID_ROOM_TYPE_B).build();
+        assertTrue(ROOM_A.isSameRoom(editedRoomA));
+
+        // different tags, same floor and room number -> returns true
+        editedRoomA = new RoomBuilder(ROOM_A).withTags(VALID_TAG_DAMAGED).build();
+        assertTrue(ROOM_A.isSameRoom(editedRoomA));
+
+        // different floor -> returns false
+        editedRoomA = new RoomBuilder(ROOM_A).withFloor(VALID_FLOOR_B).build();
+        assertFalse(ROOM_A.isSameRoom(editedRoomA));
+
+        // different room number -> returns false
+        editedRoomA = new RoomBuilder(ROOM_A).withRoomNumber(VALID_ROOM_NUMBER_B).build();
+        assertFalse(ROOM_A.isSameRoom(editedRoomA));
     }
 
     @Test
-    void getRoomType() {
-    }
+    public void equals() {
+        // same values -> returns true
+        Room roomACopy = new RoomBuilder(ROOM_A).build();
+        assertTrue(ROOM_A.equals(roomACopy));
 
-    @Test
-    void getTags() {
-    }
+        // same object -> returns true
+        assertTrue(ROOM_A.equals(ROOM_A));
 
-    @Test
-    void isSameRoom() {
+        // null -> returns false
+        assertFalse(ROOM_A.equals(null));
+
+        // different type -> returns false
+        assertFalse(ROOM_A.equals(7));
+
+        // different room -> returns false
+        assertFalse(ROOM_A.equals(ROOM_B));
+
+        // different floor -> returns false
+        Room editedRoomA = new RoomBuilder(ROOM_A).withFloor(VALID_FLOOR_B).build();
+        assertFalse(ROOM_A.equals(editedRoomA));
+
+        // different room number -> returns false
+        editedRoomA = new RoomBuilder(ROOM_A).withRoomNumber(VALID_ROOM_NUMBER_B).build();
+        assertFalse(ROOM_A.equals(editedRoomA));
+
+        // different room type -> returns false
+        editedRoomA = new RoomBuilder(ROOM_A).withRoomType(VALID_ROOM_TYPE_B).build();
+        assertFalse(ROOM_A.equals(editedRoomA));
+
+        // different tags -> returns false
+        editedRoomA = new RoomBuilder(ROOM_A).withTags(VALID_TAG_DAMAGED).build();
+        assertFalse(ROOM_A.equals(editedRoomA));
     }
 }

--- a/src/test/java/seedu/resireg/model/room/UniqueRoomListTest.java
+++ b/src/test/java/seedu/resireg/model/room/UniqueRoomListTest.java
@@ -1,34 +1,170 @@
 package seedu.resireg.model.room;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ROOM_TYPE_B;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_TAG_DAMAGED;
+import static seedu.resireg.testutil.Assert.assertThrows;
+import static seedu.resireg.testutil.TypicalRooms.ROOM_A;
+import static seedu.resireg.testutil.TypicalRooms.ROOM_B;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
-class UniqueRoomListTest {
+import seedu.resireg.model.room.exceptions.DuplicateRoomException;
+import seedu.resireg.model.room.exceptions.RoomNotFoundException;
+import seedu.resireg.testutil.RoomBuilder;
+
+public class UniqueRoomListTest {
+
+    private final UniqueRoomList uniqueRoomList = new UniqueRoomList();
 
     @Test
-    void contains() {
+    public void contains_nullRoom_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueRoomList.contains(null));
     }
 
     @Test
-    void add() {
+    public void contains_roomNotInList_returnsFalse() {
+        assertFalse(uniqueRoomList.contains(ROOM_A));
     }
 
     @Test
-    void setRoom() {
+    public void contains_roomInList_returnsTrue() {
+        uniqueRoomList.add(ROOM_A);
+        assertTrue(uniqueRoomList.contains(ROOM_A));
     }
 
     @Test
-    void remove() {
+    public void contains_roomWithSameIdentityFieldsInList_returnsTrue() {
+        uniqueRoomList.add(ROOM_A);
+        Room editedRoomA = new RoomBuilder(ROOM_A).withRoomType(VALID_ROOM_TYPE_B).withTags(VALID_TAG_DAMAGED)
+                .build();
+        assertTrue(uniqueRoomList.contains(editedRoomA));
     }
 
     @Test
-    void setRooms() {
+    public void add_nullRoom_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueRoomList.add(null));
     }
 
     @Test
-    void testSetRooms() {
+    public void add_duplicateRoom_throwsDuplicateRoomException() {
+        uniqueRoomList.add(ROOM_A);
+        assertThrows(DuplicateRoomException.class, () -> uniqueRoomList.add(ROOM_A));
     }
 
     @Test
-    void asUnmodifiableObservableList() {
+    public void setRoom_nullTargetRoom_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueRoomList.setRoom(null, ROOM_A));
+    }
+
+    @Test
+    public void setRoom_nullEditedRoom_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueRoomList.setRoom(ROOM_A, null));
+    }
+
+    @Test
+    public void setRoom_targetRoomNotInList_throwsRoomNotFoundException() {
+        assertThrows(RoomNotFoundException.class, () -> uniqueRoomList.setRoom(ROOM_A, ROOM_A));
+    }
+
+    @Test
+    public void setRoom_editedRoomIsSameRoom_success() {
+        uniqueRoomList.add(ROOM_A);
+        uniqueRoomList.setRoom(ROOM_A, ROOM_A);
+        UniqueRoomList expectedUniqueRoomList = new UniqueRoomList();
+        expectedUniqueRoomList.add(ROOM_A);
+        assertEquals(expectedUniqueRoomList, uniqueRoomList);
+    }
+
+    @Test
+    public void setRoom_editedRoomHasSameIdentity_success() {
+        uniqueRoomList.add(ROOM_A);
+        Room editedRoomA = new RoomBuilder(ROOM_A).withRoomType(VALID_ROOM_TYPE_B).withTags(VALID_TAG_DAMAGED)
+                .build();
+        uniqueRoomList.setRoom(ROOM_A, editedRoomA);
+        UniqueRoomList expectedUniqueRoomList = new UniqueRoomList();
+        expectedUniqueRoomList.add(editedRoomA);
+        assertEquals(expectedUniqueRoomList, uniqueRoomList);
+    }
+
+    @Test
+    public void setRoom_editedRoomHasDifferentIdentity_success() {
+        uniqueRoomList.add(ROOM_A);
+        uniqueRoomList.setRoom(ROOM_A, ROOM_B);
+        UniqueRoomList expectedUniqueRoomList = new UniqueRoomList();
+        expectedUniqueRoomList.add(ROOM_B);
+        assertEquals(expectedUniqueRoomList, uniqueRoomList);
+    }
+
+    @Test
+    public void setRoom_editedRoomHasNonUniqueIdentity_throwsDuplicateRoomException() {
+        uniqueRoomList.add(ROOM_A);
+        uniqueRoomList.add(ROOM_B);
+        assertThrows(DuplicateRoomException.class, () -> uniqueRoomList.setRoom(ROOM_A, ROOM_B));
+    }
+
+    @Test
+    public void remove_nullRoom_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueRoomList.remove(null));
+    }
+
+    @Test
+    public void remove_roomDoesNotExist_throwsRoomNotFoundException() {
+        assertThrows(RoomNotFoundException.class, () -> uniqueRoomList.remove(ROOM_A));
+    }
+
+    @Test
+    public void remove_existingRoom_removesRoom() {
+        uniqueRoomList.add(ROOM_A);
+        uniqueRoomList.remove(ROOM_A);
+        UniqueRoomList expectedUniqueRoomList = new UniqueRoomList();
+        assertEquals(expectedUniqueRoomList, uniqueRoomList);
+    }
+
+    @Test
+    public void setRooms_nullUniqueRoomList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueRoomList.setRooms((UniqueRoomList) null));
+    }
+
+    @Test
+    public void setRooms_uniqueRoomList_replacesOwnListWithProvidedUniqueRoomList() {
+        uniqueRoomList.add(ROOM_A);
+        UniqueRoomList expectedUniqueRoomList = new UniqueRoomList();
+        expectedUniqueRoomList.add(ROOM_B);
+        uniqueRoomList.setRooms(expectedUniqueRoomList);
+        assertEquals(expectedUniqueRoomList, uniqueRoomList);
+    }
+
+    @Test
+    public void setRooms_nullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueRoomList.setRooms((List<Room>) null));
+    }
+
+    @Test
+    public void setRooms_list_replacesOwnListWithProvidedList() {
+        uniqueRoomList.add(ROOM_A);
+        List<Room> roomList = Collections.singletonList(ROOM_B);
+        uniqueRoomList.setRooms(roomList);
+        UniqueRoomList expectedUniqueRoomList = new UniqueRoomList();
+        expectedUniqueRoomList.add(ROOM_B);
+        assertEquals(expectedUniqueRoomList, uniqueRoomList);
+    }
+
+    @Test
+    public void setRooms_listWithDuplicateRooms_throwsDuplicateRoomException() {
+        List<Room> listWithDuplicateRooms = Arrays.asList(ROOM_A, ROOM_A);
+        assertThrows(DuplicateRoomException.class, () -> uniqueRoomList.setRooms(listWithDuplicateRooms));
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, ()
+            -> uniqueRoomList.asUnmodifiableObservableList().remove(0));
     }
 }

--- a/src/test/java/seedu/resireg/testutil/TypicalRooms.java
+++ b/src/test/java/seedu/resireg/testutil/TypicalRooms.java
@@ -1,0 +1,67 @@
+package seedu.resireg.testutil;
+
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_FLOOR_A;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_FLOOR_B;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ROOM_NUMBER_A;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ROOM_NUMBER_B;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ROOM_TYPE_A;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ROOM_TYPE_B;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_TAG_DAMAGED;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_TAG_RENOVATED;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.resireg.model.AddressBook;
+import seedu.resireg.model.room.Room;
+
+/**
+ * A utility class containing a list of {@code Room} objects to be used in tests.
+ */
+public class TypicalRooms {
+    public static final Room ROOM_ONE = new RoomBuilder().withFloor("19")
+            .withRoomNumber("112")
+            .withRoomType("CA")
+            .withTags("repaired").build();
+    public static final Room ROOM_TWO = new RoomBuilder().withFloor("4")
+            .withRoomNumber("102")
+            .withRoomType("CN")
+            .withTags("deserted").build();
+    public static final Room ROOM_THREE = new RoomBuilder().withFloor("5")
+            .withRoomNumber("107")
+            .withRoomType("NN")
+            .withTags("stuffy").build();
+    public static final Room ROOM_FOUR = new RoomBuilder().withFloor("8")
+            .withRoomNumber("107")
+            .withRoomType("NA")
+            .withTags("musical").build();
+    public static final Room ROOM_FIVE = new RoomBuilder().withFloor("9")
+            .withRoomNumber("103")
+            .withRoomType("CN")
+            .withTags("airy").build();
+
+    // Manually added - Room's details found in {@code CommandTestUtil}
+    public static final Room ROOM_A = new RoomBuilder().withFloor(VALID_FLOOR_A)
+            .withRoomNumber(VALID_ROOM_NUMBER_A).withRoomType(VALID_ROOM_TYPE_A).withTags(VALID_TAG_RENOVATED).build();
+    public static final Room ROOM_B = new RoomBuilder().withFloor(VALID_FLOOR_B)
+            .withRoomNumber(VALID_ROOM_NUMBER_B).withRoomType(VALID_ROOM_TYPE_B).withTags(VALID_TAG_DAMAGED).build();
+
+    private TypicalRooms() {} // prevents instantiation
+
+    /**
+     * Returns an {@code AddressBook} with all the typical rooms.
+     */
+    public static AddressBook getTypicalAddressBook() {
+        AddressBook ab = new AddressBook();
+        for (Room room : getTypicalRooms()) {
+            ab.addRoom(room);
+        }
+        return ab;
+    }
+
+    public static List<Room> getTypicalRooms() {
+        return new ArrayList<>(Arrays.asList(ROOM_ONE, ROOM_TWO, ROOM_THREE, ROOM_FOUR, ROOM_FIVE));
+    }
+}
+


### PR DESCRIPTION
This PR adds testing support for the Room model. Specifically, it adds a new utility class `TypicalRooms` to contain room objects used in testing. Tests for `Room` and `UniqueRoomList` are also added, which closely follow the tests for `Student` and `UniqueStudentList`. Minor modifications to CommandTestUtil have also been made to include data for rooms for testing.

Changes made:
* Minor changes to CommandTestUtil to include data for rooms
* Add utility class `TypicalRooms`
* Add tests for `Room` under `RoomTest`
* Add tests for `UniqueRoomList` under `UniqueRoomListTest`

As part of #73, also mentioned in #75.