### PR TITLE
Add room tests

### DIFF
--- a/src/main/java/seedu/resireg/logic/commands/ToggleCommandResult.java
+++ b/src/main/java/seedu/resireg/logic/commands/ToggleCommandResult.java
@@ -29,4 +29,6 @@ public class ToggleCommandResult extends CommandResult {
                 && other instanceof ToggleCommandResult
                 && tabView == ((ToggleCommandResult) other).tabView;
     }
+
 }
+

--- a/src/main/java/seedu/resireg/model/room/RoomNameContainsKeywordPairsPredicate.java
+++ b/src/main/java/seedu/resireg/model/room/RoomNameContainsKeywordPairsPredicate.java
@@ -1,0 +1,34 @@
+package seedu.resireg.model.room;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import seedu.resireg.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Room}'s name, that is the combination
+ * of its {@code Floor} and {@code RoomNumber} (given as pairs)
+ * matches any of the keywords given.
+ */
+public class RoomNameContainsKeywordPairsPredicate implements Predicate<Room> {
+    private final List<Map.Entry<String, String>> pairList;
+
+    public RoomNameContainsKeywordPairsPredicate(List<Map.Entry<String, String>> pairList) {
+        this.pairList = pairList;
+    }
+
+    @Override
+    public boolean test(Room room) {
+        return pairList.stream()
+                .anyMatch(pair -> StringUtil.containsWordIgnoreCase(room.getFloor().value, pair.getKey())
+                        && StringUtil.containsWordIgnoreCase(room.getRoomNumber().value, pair.getValue()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RoomNameContainsKeywordPairsPredicate // instanceof handles nulls
+                && pairList.equals(((RoomNameContainsKeywordPairsPredicate) other).pairList)); // state check
+    }
+}

--- a/src/test/java/seedu/resireg/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/resireg/logic/commands/CommandTestUtil.java
@@ -117,6 +117,17 @@ public class CommandTestUtil {
 
     /**
      * Executes the given {@code command}, confirms that <br>
+     * - the returned {@link ToggleCommandResult} matches {@code expectedCommandResult} <br>
+     * - the {@code actualModel} matches {@code expectedModel}
+     */
+    public static void assertToggleCommandSuccess(Command command, Model actualModel, String expectedMessage,
+                                            Model expectedModel, TabView tabView) {
+        ToggleCommandResult expectedCommandResult = new ToggleCommandResult(expectedMessage, tabView);
+        assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
+    }
+
+    /**
+     * Executes the given {@code command}, confirms that <br>
      * - a {@code CommandException} is thrown <br>
      * - the CommandException message matches {@code expectedMessage} <br>
      * - the address book, filtered student list and selected student in {@code actualModel} remain unchanged

--- a/src/test/java/seedu/resireg/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/resireg/logic/commands/CommandTestUtil.java
@@ -13,11 +13,14 @@ import static seedu.resireg.testutil.Assert.assertThrows;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import seedu.resireg.commons.core.index.Index;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.AddressBook;
 import seedu.resireg.model.Model;
+import seedu.resireg.model.room.Room;
+import seedu.resireg.model.room.RoomNameContainsKeywordPairsPredicate;
 import seedu.resireg.model.student.NameContainsKeywordsPredicate;
 import seedu.resireg.model.student.Student;
 import seedu.resireg.testutil.EditStudentDescriptorBuilder;
@@ -140,6 +143,22 @@ public class CommandTestUtil {
         model.updateFilteredStudentList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredStudentList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the room at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showRoomAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredRoomList().size());
+
+        Room room = model.getFilteredRoomList().get(targetIndex.getZeroBased());
+        final String[] info = new String[]{room.getFloor().value, room.getRoomNumber().value};
+        model.updateFilteredRoomList(
+                new RoomNameContainsKeywordPairsPredicate(Arrays.asList(Map.entry(info[0], info[1])))
+        );
+
+        assertEquals(1, model.getFilteredRoomList().size());
     }
 
 }

--- a/src/test/java/seedu/resireg/logic/commands/ListRoomCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/ListRoomCommandTest.java
@@ -1,6 +1,6 @@
 package seedu.resireg.logic.commands;
 
-import static seedu.resireg.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.resireg.logic.commands.CommandTestUtil.assertToggleCommandSuccess;
 import static seedu.resireg.logic.commands.CommandTestUtil.showRoomAtIndex;
 import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_ROOM;
 import static seedu.resireg.testutil.TypicalRooms.getTypicalAddressBook;
@@ -14,6 +14,9 @@ import seedu.resireg.model.UserPrefs;
 
 public class ListRoomCommandTest {
 
+    private static final boolean SHOULD_DISPLAY = true;
+    private static final boolean SHOULD_NOT_DISPLAY = false;
+
     private Model model;
     private Model expectedModel;
 
@@ -25,12 +28,17 @@ public class ListRoomCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListRoomCommand(), model, ListRoomCommand.MESSAGE_SUCCESS, expectedModel);
+        assertToggleCommandSuccess(
+                new ListRoomCommand(SHOULD_NOT_DISPLAY),
+                model, ListRoomCommand.MESSAGE_SUCCESS, expectedModel, TabView.ROOMS);
     }
 
     @Test
     void execute_listIsFiltered_showsEverything() {
         showRoomAtIndex(model, INDEX_FIRST_ROOM);
-        assertCommandSuccess(new ListRoomCommand(), model, ListRoomCommand.MESSAGE_SUCCESS, expectedModel);
+        assertToggleCommandSuccess(
+                new ListRoomCommand(SHOULD_DISPLAY),
+                model,
+                ListRoomCommand.MESSAGE_VACANT_SUCCESS, expectedModel, TabView.ROOMS);
     }
 }

--- a/src/test/java/seedu/resireg/logic/commands/ListRoomCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/ListRoomCommandTest.java
@@ -1,10 +1,36 @@
 package seedu.resireg.logic.commands;
 
+import static seedu.resireg.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.resireg.logic.commands.CommandTestUtil.showRoomAtIndex;
+import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_ROOM;
+import static seedu.resireg.testutil.TypicalRooms.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ListRoomCommandTest {
+import seedu.resireg.model.Model;
+import seedu.resireg.model.ModelManager;
+import seedu.resireg.model.UserPrefs;
+
+public class ListRoomCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
 
     @Test
-    void execute() {
+    public void execute_listIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListRoomCommand(), model, ListRoomCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    void execute_listIsFiltered_showsEverything() {
+        showRoomAtIndex(model, INDEX_FIRST_ROOM);
+        assertCommandSuccess(new ListRoomCommand(), model, ListRoomCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/resireg/model/room/RoomNameContainsKeywordPairsPredicateTest.java
+++ b/src/test/java/seedu/resireg/model/room/RoomNameContainsKeywordPairsPredicateTest.java
@@ -1,0 +1,84 @@
+package seedu.resireg.model.room;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.resireg.testutil.RoomBuilder;
+
+public class RoomNameContainsKeywordPairsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<Map.Entry<String, String>> firstPredicateKeywordList =
+                Collections.singletonList(Map.entry("1", "2"));
+        List<Map.Entry<String, String>> secondPredicateKeywordList =
+                Arrays.asList(Map.entry("1", "2"), Map.entry("3", "4"));
+
+        RoomNameContainsKeywordPairsPredicate firstPredicate =
+                new RoomNameContainsKeywordPairsPredicate(firstPredicateKeywordList);
+        RoomNameContainsKeywordPairsPredicate secondPredicate =
+                new RoomNameContainsKeywordPairsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        RoomNameContainsKeywordPairsPredicate firstPredicateCopy =
+                new RoomNameContainsKeywordPairsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different student -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_nameContainsPairs_returnsTrue() {
+        // Matching Keyword
+        RoomNameContainsKeywordPairsPredicate predicate =
+                new RoomNameContainsKeywordPairsPredicate(Collections.singletonList(Map.entry("11", "108")));
+        assertTrue(predicate.test(new RoomBuilder().withFloor("11").withRoomNumber("108").build()));
+
+        // Only one matching keyword
+        predicate = new RoomNameContainsKeywordPairsPredicate(
+                Arrays.asList(Map.entry("11", "108"), Map.entry("12", "109"))
+        );
+        assertTrue(predicate.test(new RoomBuilder().withFloor("11").withRoomNumber("108").build()));
+    }
+
+    @Test
+    public void test_nameDoesNotContainPairs_returnsFalse() {
+        // Zero keywords
+        RoomNameContainsKeywordPairsPredicate predicate =
+                new RoomNameContainsKeywordPairsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new RoomBuilder().withFloor("11").build()));
+
+        // Non-matching pair (one keyword, floor does not match)
+        predicate =
+                new RoomNameContainsKeywordPairsPredicate(Collections.singletonList(Map.entry("11", "108")));
+        assertFalse(predicate.test(new RoomBuilder().withFloor("12").withRoomNumber("108").build()));
+
+        // Non-matching pair (one keyword, room number does not match)
+        predicate =
+                new RoomNameContainsKeywordPairsPredicate(Collections.singletonList(Map.entry("11", "108")));
+        assertFalse(predicate.test(new RoomBuilder().withFloor("11").withRoomNumber("109").build()));
+
+        // Non-matching pair (both keywords)
+        predicate =
+                new RoomNameContainsKeywordPairsPredicate(Collections.singletonList(Map.entry("11", "108")));
+        assertFalse(predicate.test(new RoomBuilder().withFloor("12").withRoomNumber("109").build()));
+    }
+
+}

--- a/src/test/java/seedu/resireg/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/resireg/testutil/TypicalIndexes.java
@@ -9,4 +9,8 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+
+    public static final Index INDEX_FIRST_ROOM = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_ROOM = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD_ROOM = Index.fromOneBased(3);
 }


### PR DESCRIPTION
This PR adds testing support for `ListRoomCommand`. Specifically, it adds a new predicate class `RoomNameContainsKeywordPairsPredicate` (which has been tested, see `RoomNameContainsKeywordPairsPredicateTest`) that is used by `ListRoomCommand`. Minor modifications to CommandTestUtil and TypricalIndexes have also been made to add methods that facilitate testing and add index objects for testing respectively. Tests for ListRoomCommand are then added, with some needed quick fixes due to added features for `ListRoomCommand`. 

Changes made:

* Add methods `showRoomAtIndex` and `assertToggleCommandSuccess` to `CommandTestUtil` 
* Add `RoomNameContainsKeywordPairsPredicate` and its associated test class
* Add testing support for `ListRoomCommand` (Note: Quick fixes are present here)

As part of #73, also mentioned in #75.