### PR TITLE
Implement viewing of allocated rooms

### DIFF
--- a/src/main/java/seedu/resireg/logic/commands/ListRoomCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ListRoomCommand.java
@@ -56,4 +56,11 @@ public class ListRoomCommand extends Command {
         }
         return new ToggleCommandResult(message, TabView.ROOMS);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ListRoomCommand) // instanceof handles nulls
+                && filter.equals(((ListRoomCommand) other).filter);
+    }
 }

--- a/src/main/java/seedu/resireg/logic/commands/ListRoomCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ListRoomCommand.java
@@ -9,32 +9,51 @@ import seedu.resireg.model.Model;
  */
 public class ListRoomCommand extends Command {
     public static final String COMMAND_WORD = "rooms";
-    public static final String COMMAND_VACANT_FLAG = "--vacant";
+    public static final String COMMAND_VACANT_FLAG = "vacant";
+    public static final String COMMAND_ALLOCATED_FLAG = "allocated";
 
     public static final String MESSAGE_SUCCESS = "Listed all rooms";
     public static final String MESSAGE_VACANT_SUCCESS = "Listed all vacant rooms";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all rooms within the system. If the "
+    public static final String MESSAGE_ALLOCATED_SUCCESS = "Listed all allocated rooms";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all rooms within the system. If the --"
             + COMMAND_VACANT_FLAG
-            + " parameter is specified, find only rooms that are vacant, meaning no students are assigned to them.\n"
-            + "Parameters: [" + COMMAND_VACANT_FLAG + "]...\n"
+            + " flag is specified, find only rooms that are vacant, meaning no students are assigned to them. "
+            + "Otherwise, if the --" + COMMAND_ALLOCATED_FLAG + " flag is specified, "
+            + "find only rooms that have students assigned to them.\n"
+            + "Parameters: [--" + COMMAND_VACANT_FLAG + "|" + COMMAND_ALLOCATED_FLAG + "]\n"
             + "Example: " + COMMAND_WORD;
 
-    private final boolean shouldDisplayOnlyVacant;
+    private final ListRoomFilter filter;
 
-    public ListRoomCommand(boolean shouldDisplayOnlyVacant) {
-        this.shouldDisplayOnlyVacant = shouldDisplayOnlyVacant;
+    public ListRoomCommand(ListRoomFilter filter) {
+        this.filter = filter;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
 
-        if (shouldDisplayOnlyVacant) {
-            model.updateFilteredRoomList(room -> !room.hasStudent());
-            return new ToggleCommandResult(MESSAGE_VACANT_SUCCESS, TabView.ROOMS);
-        } else {
+        String message = MESSAGE_SUCCESS;
+        switch (filter) {
+        case ALL: {
             model.updateFilteredRoomList(Model.PREDICATE_SHOW_ALL_ROOMS);
-            return new ToggleCommandResult(MESSAGE_SUCCESS, TabView.ROOMS);
+            message = MESSAGE_SUCCESS;
+            break;
         }
+        case VACANT: {
+            model.updateFilteredRoomList(Model.PREDICATE_SHOW_VACANT_ROOMS);
+            message = MESSAGE_VACANT_SUCCESS;
+            break;
+        }
+        case ALLOCATED: {
+            model.updateFilteredRoomList(Model.PREDICATE_SHOW_ALLOCATED_ROOMS);
+            message = MESSAGE_ALLOCATED_SUCCESS;
+            break;
+        }
+        default:
+            break;
+        }
+        return new ToggleCommandResult(message, TabView.ROOMS);
     }
 }

--- a/src/main/java/seedu/resireg/logic/commands/ListRoomFilter.java
+++ b/src/main/java/seedu/resireg/logic/commands/ListRoomFilter.java
@@ -1,0 +1,7 @@
+package seedu.resireg.logic.commands;
+
+public enum ListRoomFilter {
+    ALL,
+    VACANT,
+    ALLOCATED
+}

--- a/src/main/java/seedu/resireg/logic/parser/ListRoomCommandParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/ListRoomCommandParser.java
@@ -3,6 +3,7 @@ package seedu.resireg.logic.parser;
 import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.resireg.logic.commands.ListRoomCommand;
+import seedu.resireg.logic.commands.ListRoomFilter;
 import seedu.resireg.logic.parser.exceptions.ParseException;
 
 public class ListRoomCommandParser implements Parser<ListRoomCommand> {
@@ -11,9 +12,18 @@ public class ListRoomCommandParser implements Parser<ListRoomCommand> {
         String trimmedArgs = args.strip();
 
         if (trimmedArgs.isEmpty()) {
-            return new ListRoomCommand(false);
-        } else if (trimmedArgs.equalsIgnoreCase(ListRoomCommand.COMMAND_VACANT_FLAG)) {
-            return new ListRoomCommand(true);
+            return new ListRoomCommand(ListRoomFilter.ALL);
+        }
+        if (!trimmedArgs.startsWith("--")) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListRoomCommand.MESSAGE_USAGE));
+        }
+        trimmedArgs = trimmedArgs.substring(2); // "strip away the leading "--"
+        if (trimmedArgs.equalsIgnoreCase(ListRoomCommand.COMMAND_VACANT_FLAG)) {
+            return new ListRoomCommand(ListRoomFilter.VACANT);
+        }
+        if (trimmedArgs.equalsIgnoreCase(ListRoomCommand.COMMAND_ALLOCATED_FLAG)) {
+            return new ListRoomCommand(ListRoomFilter.ALLOCATED);
         }
         throw new ParseException(
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListRoomCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/resireg/model/Model.java
+++ b/src/main/java/seedu/resireg/model/Model.java
@@ -19,6 +19,16 @@ public interface Model {
     Predicate<Room> PREDICATE_SHOW_ALL_ROOMS = unused -> true;
 
     /**
+     * {@Code Predicate} that evaluate to true only if the room is vacant, meaning no student is occupying it.
+     */
+    Predicate<Room> PREDICATE_SHOW_VACANT_ROOMS = room -> !room.hasStudent();
+
+    /**
+     * {@Code Predicate} that evaluate to true only if the room is occupied, meaning there is a student occupying it.
+     */
+    Predicate<Room> PREDICATE_SHOW_ALLOCATED_ROOMS = Room::hasStudent;
+
+    /**
      * Replaces user prefs data with the data in {@code userPrefs}.
      */
     void setUserPrefs(ReadOnlyUserPrefs userPrefs);

--- a/src/test/java/seedu/resireg/logic/commands/ListRoomCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/ListRoomCommandTest.java
@@ -33,7 +33,7 @@ public class ListRoomCommandTest {
     }
 
     @Test
-    void execute_listIsFiltered_showsEverything() {
+    void execute_listFilterIsVacant_showsOnlyVacantRooms() {
         expectedModel.updateFilteredRoomList(Model.PREDICATE_SHOW_VACANT_ROOMS);
         assertToggleCommandSuccess(
                 new ListRoomCommand(DISPLAY_VACANT),
@@ -42,7 +42,7 @@ public class ListRoomCommandTest {
     }
 
     @Test
-    void execute_listIsVacant() {
+    void execute_listFilterIsAllocated_showsOnlyAllocatedRooms() {
         expectedModel.updateFilteredRoomList(Model.PREDICATE_SHOW_ALLOCATED_ROOMS);
         var cmd = new ListRoomCommand(DISPLAY_ALLOCATED);
         assertToggleCommandSuccess(

--- a/src/test/java/seedu/resireg/logic/commands/ListRoomCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/ListRoomCommandTest.java
@@ -1,8 +1,6 @@
 package seedu.resireg.logic.commands;
 
 import static seedu.resireg.logic.commands.CommandTestUtil.assertToggleCommandSuccess;
-import static seedu.resireg.logic.commands.CommandTestUtil.showRoomAtIndex;
-import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_ROOM;
 import static seedu.resireg.testutil.TypicalRooms.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -14,8 +12,9 @@ import seedu.resireg.model.UserPrefs;
 
 public class ListRoomCommandTest {
 
-    private static final boolean SHOULD_DISPLAY = true;
-    private static final boolean SHOULD_NOT_DISPLAY = false;
+    private static final ListRoomFilter DISPLAY_ALL = ListRoomFilter.ALL;
+    private static final ListRoomFilter DISPLAY_VACANT = ListRoomFilter.VACANT;
+    private static final ListRoomFilter DISPLAY_ALLOCATED = ListRoomFilter.ALLOCATED;
 
     private Model model;
     private Model expectedModel;
@@ -29,16 +28,26 @@ public class ListRoomCommandTest {
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
         assertToggleCommandSuccess(
-                new ListRoomCommand(SHOULD_NOT_DISPLAY),
+                new ListRoomCommand(DISPLAY_ALL),
                 model, ListRoomCommand.MESSAGE_SUCCESS, expectedModel, TabView.ROOMS);
     }
 
     @Test
     void execute_listIsFiltered_showsEverything() {
-        showRoomAtIndex(model, INDEX_FIRST_ROOM);
+        expectedModel.updateFilteredRoomList(Model.PREDICATE_SHOW_VACANT_ROOMS);
         assertToggleCommandSuccess(
-                new ListRoomCommand(SHOULD_DISPLAY),
+                new ListRoomCommand(DISPLAY_VACANT),
                 model,
                 ListRoomCommand.MESSAGE_VACANT_SUCCESS, expectedModel, TabView.ROOMS);
+    }
+
+    @Test
+    void execute_listIsVacant() {
+        expectedModel.updateFilteredRoomList(Model.PREDICATE_SHOW_ALLOCATED_ROOMS);
+        var cmd = new ListRoomCommand(DISPLAY_ALLOCATED);
+        assertToggleCommandSuccess(
+                cmd,
+                model,
+                ListRoomCommand.MESSAGE_ALLOCATED_SUCCESS, expectedModel, TabView.ROOMS);
     }
 }

--- a/src/test/java/seedu/resireg/logic/parser/ListRoomCommandParserTest.java
+++ b/src/test/java/seedu/resireg/logic/parser/ListRoomCommandParserTest.java
@@ -1,0 +1,61 @@
+package seedu.resireg.logic.parser;
+
+import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.resireg.logic.commands.ListRoomCommand;
+import seedu.resireg.logic.commands.ListRoomFilter;
+
+class ListRoomCommandParserTest {
+
+    private final ListRoomCommandParser parser = new ListRoomCommandParser();
+
+    @Test
+    void parse_whitespaceOnlyArg_returnsListRoomCommand() {
+        ListRoomCommand expectedListRoomCommand = new ListRoomCommand(ListRoomFilter.ALL);
+
+        // empty input
+        assertParseSuccess(parser, "", expectedListRoomCommand);
+
+        // whitespace
+        assertParseSuccess(parser, "            ", expectedListRoomCommand);
+
+        // tabs
+        assertParseSuccess(parser, "\t", expectedListRoomCommand);
+
+        // tabs
+        assertParseSuccess(parser, "         \t       ", expectedListRoomCommand);
+    }
+
+    @Test
+    void parse_validVacantCommand_returnsListRoomCommand() {
+        ListRoomCommand expectedListRoomCommand = new ListRoomCommand(ListRoomFilter.VACANT);
+        assertParseSuccess(parser, "--" + ListRoomCommand.COMMAND_VACANT_FLAG, expectedListRoomCommand);
+    }
+
+    @Test
+    void parse_validAllocatedCommand_returnsListRoomCommand() {
+        ListRoomCommand expectedListRoomCommand = new ListRoomCommand(ListRoomFilter.ALLOCATED);
+        assertParseSuccess(parser, "--" + ListRoomCommand.COMMAND_ALLOCATED_FLAG, expectedListRoomCommand);
+    }
+
+    @Test
+    void parse_invalidOptionalArgs_throwsParseException() {
+        // missing flag
+        assertParseFailure(parser, "--",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListRoomCommand.MESSAGE_USAGE));
+        // no two dashes
+        assertParseFailure(parser, "-",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListRoomCommand.MESSAGE_USAGE));
+        // misspelled vacant
+        assertParseFailure(parser, "--vacent",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListRoomCommand.MESSAGE_USAGE));
+        // misspelled allocated
+        assertParseFailure(parser, "-allokated",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListRoomCommand.MESSAGE_USAGE));
+    }
+
+}


### PR DESCRIPTION
This PR adds an `--allocated` flag to `rooms`, so we can view only allocated rooms.

There's not much code change, because while working on `--vacant`, most of the structure was conveniently fleshed out. I've updated the tests as well.

Closes #17 .

### How to Test
Try running `rooms --allocated`. Only allocated rooms should be displayed in the Rooms tab on the right.