### PR TITLE
Functionality Increment: Reallocate Command

### DIFF
--- a/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
@@ -1,0 +1,95 @@
+package seedu.resireg.logic.commands;
+
+import seedu.resireg.commons.core.Messages;
+import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.commands.exceptions.CommandException;
+import seedu.resireg.model.Model;
+import seedu.resireg.model.room.Room;
+import seedu.resireg.model.student.Student;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_ROOM_INDEX;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_STUDENT_INDEX;
+
+
+/**
+ * Adds a student to the address book.
+ */
+public class ReallocateCommand extends Command {
+
+    public static final String COMMAND_WORD = "reallocate";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Reallocates a student to a room. \n"
+            + "Parameters: "
+            + PREFIX_STUDENT_INDEX + "STUDENT INDEX "
+            + PREFIX_ROOM_INDEX + "ROOM INDEX\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_STUDENT_INDEX + "1 "
+            + PREFIX_ROOM_INDEX + "1";
+
+    public static final String MESSAGE_SUCCESS = "Room reallocated to %1$s: %2$s";
+    public static final String MESSAGE_ROOM_NOT_FOUND = "This room does not exist in ResiReg";
+    public static final String MESSAGE_STUDENT_NOT_FOUND = "This student is not registered in ResiReg";
+    public static final String MESSAGE_STUDENT_NOT_ALLOCATED = "This student has not been allocated a room. Please use allocate instead.";
+
+    private final Index studentIndex;
+    private final Index roomIndex;
+
+    /**
+     * @param studentIndex of the student in the filtered student list to allocate
+     * @param roomIndex of the room in the filtered room list to be allocated to
+     * Creates an AllocateCommand to allocate the specified {@code Student} to {@code Room}
+     */
+    public ReallocateCommand(Index studentIndex, Index roomIndex) {
+        requireNonNull(studentIndex);
+        requireNonNull(roomIndex);
+
+        this.studentIndex = studentIndex;
+        this.roomIndex = roomIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Student> lastShownListStudent = model.getFilteredStudentList();
+        List<Room> lastShownListRoom = model.getFilteredRoomList();
+
+        if (studentIndex.getZeroBased() >= lastShownListStudent.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        } else if (roomIndex.getZeroBased() >= lastShownListRoom.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_ROOM_DISPLAYED_INDEX);
+        }
+
+        Student studentToReallocate = lastShownListStudent.get(studentIndex.getZeroBased());
+        Room roomToReallocate = lastShownListRoom.get(roomIndex.getZeroBased());
+
+        if (!model.hasStudent(studentToReallocate)) {
+            throw new CommandException(MESSAGE_STUDENT_NOT_FOUND);
+        } else if (!model.hasRoom(roomToReallocate)) {
+            throw new CommandException(MESSAGE_ROOM_NOT_FOUND);
+        } else if (!studentToReallocate.hasRoom()) {
+            throw new CommandException(MESSAGE_STUDENT_NOT_ALLOCATED);
+        }
+
+        studentToReallocate.getRoom().unsetStudent();
+        studentToReallocate.setRoom(roomToReallocate);
+        roomToReallocate.setStudent(studentToReallocate);
+
+        model.setStudent(studentToReallocate, studentToReallocate);
+        model.setRoom(roomToReallocate, roomToReallocate);
+
+        model.updateFilteredStudentList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredRoomList(Model.PREDICATE_SHOW_ALL_ROOMS);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, studentToReallocate, roomToReallocate));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ReallocateCommand // instanceof handles nulls
+                && studentIndex.equals(((ReallocateCommand) other).studentIndex)
+                && roomIndex.equals(((ReallocateCommand) other).roomIndex));
+    }
+}

--- a/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
@@ -40,7 +40,7 @@ public class ReallocateCommand extends Command {
     /**
      * @param studentIndex of the student in the filtered student list to allocate
      * @param roomIndex of the room in the filtered room list to be allocated to
-     * Creates an AllocateCommand to allocate the specified {@code Student} to {@code Room}
+     * Creates an ReallocateCommand to allocate the specified {@code Student} to {@code Room}
      */
     public ReallocateCommand(Index studentIndex, Index roomIndex) {
         requireNonNull(studentIndex);

--- a/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
@@ -1,17 +1,17 @@
 package seedu.resireg.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_ROOM_INDEX;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_STUDENT_INDEX;
+
+import java.util.List;
+
 import seedu.resireg.commons.core.Messages;
 import seedu.resireg.commons.core.index.Index;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.Student;
-
-import java.util.List;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.resireg.logic.parser.CliSyntax.PREFIX_ROOM_INDEX;
-import static seedu.resireg.logic.parser.CliSyntax.PREFIX_STUDENT_INDEX;
 
 
 /**
@@ -31,7 +31,8 @@ public class ReallocateCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Room reallocated to %1$s: %2$s";
     public static final String MESSAGE_ROOM_NOT_FOUND = "This room does not exist in ResiReg";
     public static final String MESSAGE_STUDENT_NOT_FOUND = "This student is not registered in ResiReg";
-    public static final String MESSAGE_STUDENT_NOT_ALLOCATED = "This student has not been allocated a room. Please use allocate instead.";
+    public static final String MESSAGE_STUDENT_NOT_ALLOCATED =
+            "This student has not been allocated a room. Please use allocate instead.";
 
     private final Index studentIndex;
     private final Index roomIndex;

--- a/src/main/java/seedu/resireg/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/AddressBookParser.java
@@ -6,17 +6,7 @@ import static seedu.resireg.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.resireg.logic.commands.AddCommand;
-import seedu.resireg.logic.commands.AllocateCommand;
-import seedu.resireg.logic.commands.ClearCommand;
-import seedu.resireg.logic.commands.Command;
-import seedu.resireg.logic.commands.DeleteCommand;
-import seedu.resireg.logic.commands.EditCommand;
-import seedu.resireg.logic.commands.ExitCommand;
-import seedu.resireg.logic.commands.FindCommand;
-import seedu.resireg.logic.commands.HelpCommand;
-import seedu.resireg.logic.commands.ListCommand;
-import seedu.resireg.logic.commands.ListRoomCommand;
+import seedu.resireg.logic.commands.*;
 import seedu.resireg.logic.parser.exceptions.ParseException;
 
 /**
@@ -75,6 +65,9 @@ public class AddressBookParser {
 
         case AllocateCommand.COMMAND_WORD:
             return new AllocateCommandParser().parse(arguments);
+
+        case ReallocateCommand.COMMAND_WORD:
+            return new ReallocateCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/resireg/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/AddressBookParser.java
@@ -6,7 +6,18 @@ import static seedu.resireg.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.resireg.logic.commands.*;
+import seedu.resireg.logic.commands.AddCommand;
+import seedu.resireg.logic.commands.AllocateCommand;
+import seedu.resireg.logic.commands.ClearCommand;
+import seedu.resireg.logic.commands.Command;
+import seedu.resireg.logic.commands.DeleteCommand;
+import seedu.resireg.logic.commands.EditCommand;
+import seedu.resireg.logic.commands.ExitCommand;
+import seedu.resireg.logic.commands.FindCommand;
+import seedu.resireg.logic.commands.HelpCommand;
+import seedu.resireg.logic.commands.ListCommand;
+import seedu.resireg.logic.commands.ListRoomCommand;
+import seedu.resireg.logic.commands.ReallocateCommand;
 import seedu.resireg.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/resireg/logic/parser/ReallocateCommandParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/ReallocateCommandParser.java
@@ -12,13 +12,13 @@ import seedu.resireg.logic.parser.exceptions.ParseException;
 
 
 /**
- * Parses input arguments and creates a new AddCommand object
+ * Parses input arguments and creates a new ReallocateCommand object
  */
 public class ReallocateCommandParser implements Parser<ReallocateCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddCommand
-     * and returns an AddCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the ReallocateCommand
+     * and returns an ReallocateCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public ReallocateCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/resireg/logic/parser/ReallocateCommandParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/ReallocateCommandParser.java
@@ -1,14 +1,15 @@
 package seedu.resireg.logic.parser;
 
+import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_ROOM_INDEX;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_STUDENT_INDEX;
+
+import java.util.stream.Stream;
+
 import seedu.resireg.commons.core.index.Index;
 import seedu.resireg.logic.commands.ReallocateCommand;
 import seedu.resireg.logic.parser.exceptions.ParseException;
 
-import java.util.stream.Stream;
-
-import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.resireg.logic.parser.CliSyntax.PREFIX_ROOM_INDEX;
-import static seedu.resireg.logic.parser.CliSyntax.PREFIX_STUDENT_INDEX;
 
 /**
  * Parses input arguments and creates a new AddCommand object

--- a/src/main/java/seedu/resireg/logic/parser/ReallocateCommandParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/ReallocateCommandParser.java
@@ -1,0 +1,50 @@
+package seedu.resireg.logic.parser;
+
+import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.commands.ReallocateCommand;
+import seedu.resireg.logic.parser.exceptions.ParseException;
+
+import java.util.stream.Stream;
+
+import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_ROOM_INDEX;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_STUDENT_INDEX;
+
+/**
+ * Parses input arguments and creates a new AddCommand object
+ */
+public class ReallocateCommandParser implements Parser<ReallocateCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand
+     * and returns an AddCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ReallocateCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_STUDENT_INDEX, PREFIX_ROOM_INDEX);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_STUDENT_INDEX, PREFIX_ROOM_INDEX)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ReallocateCommand.MESSAGE_USAGE));
+        }
+
+        try {
+            Index studentIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_STUDENT_INDEX).get());
+            Index roomIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_ROOM_INDEX).get());
+            return new ReallocateCommand(studentIndex, roomIndex);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ReallocateCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}


### PR DESCRIPTION
This PR adds the functionality increment of the Reallocate Command. Reallocation of a student from one room to another room is performed by referencing the index of the student and the **new** room in the Address Book. `si/` and `ri/` prefixes refer to the student and new room indices respectively.

Example usage:
`reallocate si/1 ri/2`

Changes made:
* Add `ReallocateCommand`, that performs 3 checks on execution:
  * Student referenced exists.
  * New room referenced exists.
  * Student has previously been allocated a room.
* Add `ReallocateCommandParser`, that parses student and room indices from `si/` and `ri/ respectively.

To be done:
* Add testing support for `ReallocateCommand` and `ReallocateCommandParser`.

As part of #18.