### PR TITLE
Fix bug where room can be allocated to multiple students

### DIFF
--- a/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
@@ -32,6 +32,7 @@ public class AllocateCommand extends Command {
     public static final String MESSAGE_ROOM_NOT_FOUND = "This room does not exist in ResiReg";
     public static final String MESSAGE_STUDENT_NOT_FOUND = "This student is not registered in ResiReg";
     public static final String MESSAGE_STUDENT_ALREADY_ALLOCATED = "This student has already been allocated a room.";
+    public static final String MESSAGE_ROOM_ALREADY_ALLOCATED = "This room has already been allocated to a student.";
 
     private final Index studentIndex;
     private final Index roomIndex;
@@ -70,6 +71,8 @@ public class AllocateCommand extends Command {
             throw new CommandException(MESSAGE_ROOM_NOT_FOUND);
         } else if (studentToAllocate.hasRoom()) {
             throw new CommandException(MESSAGE_STUDENT_ALREADY_ALLOCATED);
+        } else if (roomToAllocate.hasStudent()) {
+            throw new CommandException(MESSAGE_ROOM_ALREADY_ALLOCATED);
         }
 
         studentToAllocate.setRoom(roomToAllocate);

--- a/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
@@ -33,6 +33,7 @@ public class ReallocateCommand extends Command {
     public static final String MESSAGE_STUDENT_NOT_FOUND = "This student is not registered in ResiReg";
     public static final String MESSAGE_STUDENT_NOT_ALLOCATED =
             "This student has not been allocated a room. Please use allocate instead.";
+    public static final String MESSAGE_ROOM_ALREADY_ALLOCATED = "This room has already been allocated to a student.";
 
     private final Index studentIndex;
     private final Index roomIndex;
@@ -71,6 +72,8 @@ public class ReallocateCommand extends Command {
             throw new CommandException(MESSAGE_ROOM_NOT_FOUND);
         } else if (!studentToReallocate.hasRoom()) {
             throw new CommandException(MESSAGE_STUDENT_NOT_ALLOCATED);
+        } else if (roomToReallocate.hasStudent()) {
+            throw new CommandException(MESSAGE_ROOM_ALREADY_ALLOCATED);
         }
 
         studentToReallocate.getRoom().unsetStudent();


### PR DESCRIPTION
### What this does
This PR ensures that the allocate and reallocate commands can only allocate a student to a room which is not already occupied. This is done by checking whether or not the Room to allocate already contains a Student.

### How to test
<!-- Write an essay here if it's more suitable -->
1. Delete the existing data file and launch the application. 
2. Run `allocate si/1 ri/1`
3. Run `allocate si/2 ri/1`. This should cause an error message and the allocation should not go through.
4. Run `allocate si/2 ri/2`
5. Run `reallocate si/1 ri/2`. Again, this should cause an error message and the reallocation should not go through.

### Notes
<!-- Anything else we should take note of, e.g. how this affects future PRs,
issues faced, etc. -->
