### PR TITLE
Functionality Increment: Undo and Redo functionality (+ Keyboard shortcuts)

### DIFF
--- a/src/main/java/seedu/resireg/logic/CommandMapper.java
+++ b/src/main/java/seedu/resireg/logic/CommandMapper.java
@@ -18,6 +18,8 @@ import seedu.resireg.logic.commands.HelpCommand;
 import seedu.resireg.logic.commands.ListCommand;
 import seedu.resireg.logic.commands.ListRoomCommand;
 import seedu.resireg.logic.commands.ReallocateCommand;
+import seedu.resireg.logic.commands.RedoCommand;
+import seedu.resireg.logic.commands.UndoCommand;
 import seedu.resireg.logic.parser.AddCommandParser;
 import seedu.resireg.logic.parser.AddressBookParser;
 import seedu.resireg.logic.parser.AllocateCommandParser;
@@ -61,6 +63,8 @@ public class CommandMapper {
                 new DeallocateCommandParser()::parse);
         commandMap.addCommand(ReallocateCommand.COMMAND_WORD, ReallocateCommand.HELP,
                 new ReallocateCommandParser()::parse);
+        commandMap.addCommand(RedoCommand.COMMAND_WORD, RedoCommand.HELP, unused -> new RedoCommand());
+        commandMap.addCommand(UndoCommand.COMMAND_WORD, UndoCommand.HELP, unused -> new UndoCommand());
 
         parser = new AddressBookParser(commandMap.getCommandWordToParserMap());
     }

--- a/src/main/java/seedu/resireg/logic/CreateEditCopy.java
+++ b/src/main/java/seedu/resireg/logic/CreateEditCopy.java
@@ -1,5 +1,7 @@
 package seedu.resireg.logic;
 
+import java.util.Set;
+
 import seedu.resireg.model.room.Floor;
 import seedu.resireg.model.room.Room;
 import seedu.resireg.model.room.RoomNumber;
@@ -12,13 +14,20 @@ import seedu.resireg.model.student.StudentId;
 import seedu.resireg.model.student.faculty.Faculty;
 import seedu.resireg.model.tag.Tag;
 
-import java.util.Set;
-
 /**
  * Contains functionality for "copy-constructing" {@code Student} and {@code Room}
- * to deal with persistence of student and room allocation statuses.
+ * objects to deal with persistence of student and room allocation statuses that
+ * inhibits undo and redo functionality.
  */
 public class CreateEditCopy {
+    /**
+     * Creates a new student instance with the same information
+     * as the student it is copying from.
+     *
+     * @param studentToCopy student to copy from
+     * @return a new student instance with the same fields
+     * as the student to copy from
+     */
     public static Student createCopiedStudent(Student studentToCopy) {
         assert studentToCopy != null;
 
@@ -36,6 +45,14 @@ public class CreateEditCopy {
         return copy;
     }
 
+    /**
+     * Creates a new room instance with the same information
+     * as the room it is copying from.
+     *
+     * @param roomToCopy the room to copy from
+     * @return a new room instance with the same fields
+     * as the room to copy from
+     */
     public static Room createCopiedRoom(Room roomToCopy) {
         assert roomToCopy != null;
 

--- a/src/main/java/seedu/resireg/logic/CreateEditCopy.java
+++ b/src/main/java/seedu/resireg/logic/CreateEditCopy.java
@@ -1,0 +1,52 @@
+package seedu.resireg.logic;
+
+import seedu.resireg.model.room.Floor;
+import seedu.resireg.model.room.Room;
+import seedu.resireg.model.room.RoomNumber;
+import seedu.resireg.model.room.roomtype.RoomType;
+import seedu.resireg.model.student.Email;
+import seedu.resireg.model.student.Name;
+import seedu.resireg.model.student.Phone;
+import seedu.resireg.model.student.Student;
+import seedu.resireg.model.student.StudentId;
+import seedu.resireg.model.student.faculty.Faculty;
+import seedu.resireg.model.tag.Tag;
+
+import java.util.Set;
+
+/**
+ * Contains functionality for "copy-constructing" {@code Student} and {@code Room}
+ * to deal with persistence of student and room allocation statuses.
+ */
+public class CreateEditCopy {
+    public static Student createCopiedStudent(Student studentToCopy) {
+        assert studentToCopy != null;
+
+        Name copiedName = studentToCopy.getName();
+        Phone copiedPhone = studentToCopy.getPhone();
+        Email copiedEmail = studentToCopy.getEmail();
+        Faculty copiedFaculty = studentToCopy.getFaculty();
+        StudentId copiedStudentId = studentToCopy.getStudentId();
+        Set<Tag> copiedTags = studentToCopy.getTags();
+
+        Student copy = new Student(copiedName, copiedPhone,
+                copiedEmail, copiedFaculty, copiedStudentId, copiedTags);
+        copy.setRoom(studentToCopy.getRoom());
+
+        return copy;
+    }
+
+    public static Room createCopiedRoom(Room roomToCopy) {
+        assert roomToCopy != null;
+
+        Floor copiedFloor = roomToCopy.getFloor();
+        RoomNumber copiedRoomNumber = roomToCopy.getRoomNumber();
+        RoomType copiedRoomType = roomToCopy.getRoomType();
+        Set<Tag> copiedTags = roomToCopy.getTags();
+
+        Room copy = new Room(copiedFloor, copiedRoomNumber, copiedRoomType, copiedTags);
+        copy.setStudent(roomToCopy.getStudent());
+
+        return copy;
+    }
+}

--- a/src/main/java/seedu/resireg/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/AddCommand.java
@@ -57,6 +57,7 @@ public class AddCommand extends Command {
         }
 
         model.addStudent(toAdd);
+        model.saveStateResiReg();
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd.getName().fullName, toAdd.getStudentId().value));
     }
 

--- a/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import seedu.resireg.commons.core.Messages;
 import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.CreateEditCopy;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.room.Room;
@@ -76,14 +77,19 @@ public class AllocateCommand extends Command {
             throw new CommandException(MESSAGE_ROOM_ALREADY_ALLOCATED);
         }
 
-        studentToAllocate.setRoom(roomToAllocate);
-        roomToAllocate.setStudent(studentToAllocate);
+        Student studentToEdit = CreateEditCopy.createCopiedStudent(studentToAllocate);
+        Room roomToEdit = CreateEditCopy.createCopiedRoom(roomToAllocate);
 
-        model.setStudent(studentToAllocate, studentToAllocate);
-        model.setRoom(roomToAllocate, roomToAllocate);
+        studentToEdit.setRoom(roomToEdit);
+        roomToEdit.setStudent(studentToEdit);
+
+        model.setStudent(studentToAllocate, studentToEdit);
+        model.setRoom(roomToAllocate, roomToEdit);
 
         model.updateFilteredStudentList(Model.PREDICATE_SHOW_ALL_PERSONS);
         model.updateFilteredRoomList(Model.PREDICATE_SHOW_ALL_ROOMS);
+
+        model.saveStateResiReg();
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, roomToAllocate.getRoomLabel(),
             studentToAllocate.getName().fullName));
@@ -96,4 +102,5 @@ public class AllocateCommand extends Command {
                 && studentIndex.equals(((AllocateCommand) other).studentIndex)
                 && roomIndex.equals(((AllocateCommand) other).roomIndex));
     }
+
 }

--- a/src/main/java/seedu/resireg/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ClearCommand.java
@@ -2,8 +2,8 @@ package seedu.resireg.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.resireg.model.AddressBook;
 import seedu.resireg.model.Model;
-import seedu.resireg.model.VersionedResiReg;
 
 /**
  * Clears the address book.
@@ -18,7 +18,7 @@ public class ClearCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.setAddressBook(new VersionedResiReg());
+        model.setAddressBook(new AddressBook());
         model.saveStateResiReg();
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/resireg/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ClearCommand.java
@@ -2,8 +2,8 @@ package seedu.resireg.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import seedu.resireg.model.AddressBook;
 import seedu.resireg.model.Model;
+import seedu.resireg.model.VersionedResiReg;
 
 /**
  * Clears the address book.
@@ -18,7 +18,8 @@ public class ClearCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.setAddressBook(new AddressBook());
+        model.setAddressBook(new VersionedResiReg());
+        model.saveStateResiReg();
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/resireg/logic/commands/DeallocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/DeallocateCommand.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import seedu.resireg.commons.core.Messages;
 import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.CreateEditCopy;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.room.Room;
@@ -57,14 +58,19 @@ public class DeallocateCommand extends Command {
             throw new CommandException(MESSAGE_STUDENT_NOT_ALLOCATED);
         }
 
-        studentToDeallocate.unsetRoom();
-        roomToDeallocate.unsetStudent();
+        Student studentToEdit = CreateEditCopy.createCopiedStudent(studentToDeallocate);
+        Room roomToEdit = CreateEditCopy.createCopiedRoom(roomToDeallocate);
 
-        model.setStudent(studentToDeallocate, studentToDeallocate);
-        model.setRoom(roomToDeallocate, roomToDeallocate);
+        studentToEdit.unsetRoom();
+        roomToEdit.unsetStudent();
+
+        model.setStudent(studentToDeallocate, studentToEdit);
+        model.setRoom(roomToDeallocate, roomToEdit);
 
         model.updateFilteredStudentList(Model.PREDICATE_SHOW_ALL_PERSONS);
         model.updateFilteredRoomList(Model.PREDICATE_SHOW_ALL_ROOMS);
+
+        model.saveStateResiReg();
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, roomToDeallocate.getRoomLabel(),
             studentToDeallocate.getName().fullName));

--- a/src/main/java/seedu/resireg/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/DeleteCommand.java
@@ -40,6 +40,7 @@ public class DeleteCommand extends Command {
 
         Student studentToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteStudent(studentToDelete);
+        model.saveStateResiReg();
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, studentToDelete));
     }
 

--- a/src/main/java/seedu/resireg/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/EditCommand.java
@@ -86,6 +86,7 @@ public class EditCommand extends Command {
 
         model.setStudent(studentToEdit, editedStudent);
         model.updateFilteredStudentList(PREDICATE_SHOW_ALL_PERSONS);
+        model.saveStateResiReg();
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedStudent));
     }
 

--- a/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
@@ -82,6 +82,8 @@ public class ReallocateCommand extends Command {
         model.updateFilteredStudentList(Model.PREDICATE_SHOW_ALL_PERSONS);
         model.updateFilteredRoomList(Model.PREDICATE_SHOW_ALL_ROOMS);
 
+        model.saveStateResiReg();
+
         return new CommandResult(String.format(MESSAGE_SUCCESS, studentToReallocate.getName().fullName,
             roomToReallocate.getRoomLabel()));
     }

--- a/src/main/java/seedu/resireg/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/RedoCommand.java
@@ -1,0 +1,35 @@
+package seedu.resireg.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.resireg.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.resireg.model.Model.PREDICATE_SHOW_ALL_ROOMS;
+
+import seedu.resireg.logic.commands.exceptions.CommandException;
+import seedu.resireg.model.Model;
+
+/**
+ * Reverts the {@code model}'s ResiReg to its previously undone state.
+ */
+public class RedoCommand extends Command {
+
+    public static final String COMMAND_WORD = "redo";
+
+    public static final String MESSAGE_SUCCESS = "Redo success!";
+    public static final String MESSAGE_FAILURE = "No more commands to redo!";
+
+    public static final Help HELP = new Help(COMMAND_WORD, "Redo a previous command.");
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.canRedoResiReg()) {
+            throw new CommandException(MESSAGE_FAILURE);
+        }
+
+        model.redoResiReg();
+        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredRoomList(PREDICATE_SHOW_ALL_ROOMS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/resireg/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/UndoCommand.java
@@ -1,0 +1,34 @@
+package seedu.resireg.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.resireg.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.resireg.model.Model.PREDICATE_SHOW_ALL_ROOMS;
+
+import seedu.resireg.logic.commands.exceptions.CommandException;
+import seedu.resireg.model.Model;
+
+/**
+ * Reverts the {@code model}'s ResiReg to its previous state.
+ */
+public class UndoCommand extends Command {
+    public static final String COMMAND_WORD = "undo";
+
+    public static final String MESSAGE_SUCCESS = "Undo success!";
+    public static final String MESSAGE_FAILURE = "No more commands to undo!";
+
+    public static final Help HELP = new Help(COMMAND_WORD, "Undo a previous command");
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.canUndoResiReg()) {
+            throw new CommandException(MESSAGE_FAILURE);
+        }
+
+        model.undoResiReg();
+        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredRoomList(PREDICATE_SHOW_ALL_ROOMS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/resireg/model/Model.java
+++ b/src/main/java/seedu/resireg/model/Model.java
@@ -121,4 +121,29 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredRoomList(Predicate<Room> predicate);
+
+    /**
+     * Returns true if the model has previous ResiReg states to restore.
+     */
+    boolean canUndoResiReg();
+
+    /**
+     * Returns true if the model has undone ResiReg states to restore.
+     */
+    boolean canRedoResiReg();
+
+    /**
+     * Restores the model's ResiReg to its previous state.
+     */
+    void undoResiReg();
+
+    /**
+     * Restores the mode's ResiReg to its previously undone state.
+     */
+    void redoResiReg();
+
+    /**
+     * Saves the current ResiReg state for undo/redo.
+     */
+    void saveStateResiReg();
 }

--- a/src/main/java/seedu/resireg/model/ModelManager.java
+++ b/src/main/java/seedu/resireg/model/ModelManager.java
@@ -20,7 +20,7 @@ import seedu.resireg.model.student.Student;
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private final AddressBook addressBook;
+    private final VersionedResiReg versionedResiReg;
     private final UserPrefs userPrefs;
     private final FilteredList<Student> filteredStudents;
     private final FilteredList<Room> filteredRooms;
@@ -34,10 +34,10 @@ public class ModelManager implements Model {
 
         logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
 
-        this.addressBook = new AddressBook(addressBook);
+        versionedResiReg = new VersionedResiReg(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
-        filteredStudents = new FilteredList<>(this.addressBook.getStudentList());
-        filteredRooms = new FilteredList<>(this.addressBook.getRoomList());
+        filteredStudents = new FilteredList<>(versionedResiReg.getStudentList());
+        filteredRooms = new FilteredList<>(versionedResiReg.getRoomList());
     }
 
     public ModelManager() {
@@ -83,28 +83,28 @@ public class ModelManager implements Model {
 
     @Override
     public void setAddressBook(ReadOnlyAddressBook addressBook) {
-        this.addressBook.resetData(addressBook);
+        versionedResiReg.resetData(addressBook);
     }
 
     @Override
     public ReadOnlyAddressBook getAddressBook() {
-        return addressBook;
+        return versionedResiReg;
     }
 
     @Override
     public boolean hasStudent(Student student) {
         requireNonNull(student);
-        return addressBook.hasStudent(student);
+        return versionedResiReg.hasStudent(student);
     }
 
     @Override
     public void deleteStudent(Student target) {
-        addressBook.removeStudent(target);
+        versionedResiReg.removeStudent(target);
     }
 
     @Override
     public void addStudent(Student student) {
-        addressBook.addStudent(student);
+        versionedResiReg.addStudent(student);
         updateFilteredStudentList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
@@ -112,20 +112,20 @@ public class ModelManager implements Model {
     public void setStudent(Student target, Student editedStudent) {
         requireAllNonNull(target, editedStudent);
 
-        addressBook.setStudent(target, editedStudent);
+        versionedResiReg.setStudent(target, editedStudent);
     }
 
     @Override
     public void setRoom(Room target, Room editedRoom) {
         requireAllNonNull(target, editedRoom);
 
-        addressBook.setRoom(target, editedRoom);
+        versionedResiReg.setRoom(target, editedRoom);
     }
 
     @Override
     public boolean hasRoom(Room room) {
         requireNonNull(room);
-        return addressBook.hasRoom(room);
+        return versionedResiReg.hasRoom(room);
     }
 
     //=========== Filtered Student List Accessors =============================================================
@@ -162,6 +162,34 @@ public class ModelManager implements Model {
         filteredRooms.setPredicate(predicate);
     }
 
+    //=========== Undo/Redo =============================================================
+
+    @Override
+    public boolean canUndoResiReg() {
+        return versionedResiReg.canUndo();
+    }
+
+    @Override
+    public boolean canRedoResiReg() {
+        return versionedResiReg.canRedo();
+    }
+
+    @Override
+    public void undoResiReg() {
+        versionedResiReg.undo();
+    }
+
+    @Override
+    public void redoResiReg() {
+        versionedResiReg.redo();
+    }
+
+    @Override
+    public void saveStateResiReg() {
+        versionedResiReg.save();
+    }
+
+
     @Override
     public boolean equals(Object obj) {
         // short circuit if same object
@@ -176,7 +204,7 @@ public class ModelManager implements Model {
 
         // state check
         ModelManager other = (ModelManager) obj;
-        return addressBook.equals(other.addressBook)
+        return versionedResiReg.equals(other.versionedResiReg)
                 && userPrefs.equals(other.userPrefs)
                 && filteredStudents.equals(other.filteredStudents)
                 && filteredRooms.equals(other.filteredRooms);

--- a/src/main/java/seedu/resireg/model/VersionedResiReg.java
+++ b/src/main/java/seedu/resireg/model/VersionedResiReg.java
@@ -6,19 +6,17 @@ import java.util.List;
 import seedu.resireg.model.exceptions.NoRedoableStateException;
 import seedu.resireg.model.exceptions.NoUndoableStateException;
 
+/**
+ * {@code AddressBook} that keeps track of its own history.
+ */
 public class VersionedResiReg extends AddressBook {
 
     private final List<ReadOnlyAddressBook> resiRegStateList;
     private int currentStatePtr;
 
-    public VersionedResiReg() {
-        super();
-
-        resiRegStateList = new ArrayList<>();
-        resiRegStateList.add(new AddressBook());
-        currentStatePtr = 0;
-    }
-
+    /**
+     * Creates a {@code VersionedResiReg} with the given {@code ReadOnlyAddressBook}.
+     */
     public VersionedResiReg(ReadOnlyAddressBook initialState) {
         super(initialState);
 

--- a/src/main/java/seedu/resireg/model/VersionedResiReg.java
+++ b/src/main/java/seedu/resireg/model/VersionedResiReg.java
@@ -1,0 +1,100 @@
+package seedu.resireg.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import seedu.resireg.model.exceptions.NoRedoableStateException;
+import seedu.resireg.model.exceptions.NoUndoableStateException;
+
+public class VersionedResiReg extends AddressBook {
+
+    private final List<ReadOnlyAddressBook> resiRegStateList;
+    private int currentStatePtr;
+
+    public VersionedResiReg() {
+        super();
+
+        resiRegStateList = new ArrayList<>();
+        resiRegStateList.add(new AddressBook());
+        currentStatePtr = 0;
+    }
+
+    public VersionedResiReg(ReadOnlyAddressBook initialState) {
+        super(initialState);
+
+        resiRegStateList = new ArrayList<>();
+        resiRegStateList.add(new AddressBook(initialState));
+        currentStatePtr = 0;
+    }
+
+    private void removeStatesAfterCurrentPtr() {
+        resiRegStateList.subList(currentStatePtr + 1, resiRegStateList.size()).clear();
+    }
+
+    /**
+     * Saves a copy of the current {@code AddressBook} state at the end of
+     * the state list. Undone states are removed from the state list.
+     */
+    public void save() {
+        removeStatesAfterCurrentPtr();
+        resiRegStateList.add(new AddressBook(this));
+        currentStatePtr++;
+    }
+
+    /**
+     * Returns true if {@code undo()} has ResiReg states to undo.
+     */
+    public boolean canUndo() {
+        return currentStatePtr > 0;
+    }
+
+    /**
+     * Returns true if {@code redo()} has ResiReg states to redo.
+     */
+    public boolean canRedo() {
+        return currentStatePtr < resiRegStateList.size() - 1;
+    }
+
+    /**
+     * Restores ResiReg to its previous state
+     */
+    public void undo() {
+        if (!canUndo()) {
+            throw new NoUndoableStateException();
+        }
+        currentStatePtr--;
+        resetData(resiRegStateList.get(currentStatePtr));
+    }
+
+    /**
+     * Restores ResiReg to its previously undone state
+     */
+    public void redo() {
+        if (!canRedo()) {
+            throw new NoRedoableStateException();
+        }
+        currentStatePtr++;
+        resetData(resiRegStateList.get(currentStatePtr));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof VersionedResiReg)) {
+            return false;
+        }
+
+        VersionedResiReg otherVersionedResiReg = (VersionedResiReg) other;
+
+        // state check
+        return super.equals(otherVersionedResiReg)
+                && resiRegStateList.equals(otherVersionedResiReg.resiRegStateList)
+                && currentStatePtr == otherVersionedResiReg.currentStatePtr;
+    }
+}
+

--- a/src/main/java/seedu/resireg/model/exceptions/NoRedoableStateException.java
+++ b/src/main/java/seedu/resireg/model/exceptions/NoRedoableStateException.java
@@ -1,0 +1,11 @@
+package seedu.resireg.model.exceptions;
+
+/**
+ * Signals that {@code redo()} can't be done as there
+ * are no states to go forward to
+ */
+public class NoRedoableStateException extends RuntimeException {
+    public NoRedoableStateException() {
+        super("There are no states to redo.");
+    }
+}

--- a/src/main/java/seedu/resireg/model/exceptions/NoUndoableStateException.java
+++ b/src/main/java/seedu/resireg/model/exceptions/NoUndoableStateException.java
@@ -1,0 +1,12 @@
+package seedu.resireg.model.exceptions;
+
+/**
+ * Signals that {@code undo()} can't be done as there
+ * are no states to go back to
+ */
+public class NoUndoableStateException extends RuntimeException {
+    public NoUndoableStateException() {
+        super("There are no states to undo.");
+    }
+}
+

--- a/src/main/java/seedu/resireg/ui/CommandBox.java
+++ b/src/main/java/seedu/resireg/ui/CommandBox.java
@@ -21,9 +21,9 @@ public class CommandBox extends UiPart<Region> {
     private static final String FXML = "CommandBox.fxml";
 
     // keyboard shortcuts (can consider KeyboardCommandMapper similar to CommandMapper)
-    public static final KeyCombination undo =
+    private static final KeyCombination undo =
             new KeyCodeCombination(KeyCode.Z, KeyCombination.CONTROL_DOWN);
-    public static KeyCombination redo =
+    private static final KeyCombination redo =
             new KeyCodeCombination(KeyCode.Y, KeyCombination.CONTROL_DOWN);
 
 
@@ -31,6 +31,16 @@ public class CommandBox extends UiPart<Region> {
 
     @FXML
     private TextField commandTextField;
+
+    /**
+     * Creates a {@code CommandBox} with the given {@code CommandExecutor}.
+     */
+    public CommandBox(CommandExecutor commandExecutor) {
+        super(FXML);
+        this.commandExecutor = commandExecutor;
+        // calls #setStyleToDefault() whenever there is a change to the text of the command box.
+        commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+    }
 
     @FXML
     private void handleOnKeyPressed(KeyEvent event) {
@@ -42,16 +52,6 @@ public class CommandBox extends UiPart<Region> {
         if (redo.match(event)) {
             handleCommandEntered("redo");
         }
-    }
-
-    /**
-     * Creates a {@code CommandBox} with the given {@code CommandExecutor}.
-     */
-    public CommandBox(CommandExecutor commandExecutor) {
-        super(FXML);
-        this.commandExecutor = commandExecutor;
-        // calls #setStyleToDefault() whenever there is a change to the text of the command box.
-        commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
     }
 
     /**
@@ -75,10 +75,7 @@ public class CommandBox extends UiPart<Region> {
     }
 
     /**
-     * Sets the command entered to the given string and executes it
-     */
-    /**
-     * Handles the Enter button pressed event.
+     * Handles the Enter button pressed event
      */
     public void handleCommandEntered(String commandText) {
         try {

--- a/src/main/java/seedu/resireg/ui/CommandBox.java
+++ b/src/main/java/seedu/resireg/ui/CommandBox.java
@@ -3,6 +3,10 @@ package seedu.resireg.ui;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.resireg.logic.commands.CommandResult;
 import seedu.resireg.logic.commands.exceptions.CommandException;
@@ -16,10 +20,29 @@ public class CommandBox extends UiPart<Region> {
     public static final String ERROR_STYLE_CLASS = "error";
     private static final String FXML = "CommandBox.fxml";
 
+    // keyboard shortcuts (can consider KeyboardCommandMapper similar to CommandMapper)
+    public static final KeyCombination undo =
+            new KeyCodeCombination(KeyCode.Z, KeyCombination.CONTROL_DOWN);
+    public static KeyCombination redo =
+            new KeyCodeCombination(KeyCode.Y, KeyCombination.CONTROL_DOWN);
+
+
     private final CommandExecutor commandExecutor;
 
     @FXML
     private TextField commandTextField;
+
+    @FXML
+    private void handleOnKeyPressed(KeyEvent event) {
+
+        if (undo.match(event)) {
+            handleCommandEntered("undo");
+        }
+
+        if (redo.match(event)) {
+            handleCommandEntered("redo");
+        }
+    }
 
     /**
      * Creates a {@code CommandBox} with the given {@code CommandExecutor}.
@@ -45,6 +68,21 @@ public class CommandBox extends UiPart<Region> {
     private void handleCommandEntered() {
         try {
             commandExecutor.execute(commandTextField.getText());
+            commandTextField.setText("");
+        } catch (CommandException | ParseException e) {
+            setStyleToIndicateCommandFailure();
+        }
+    }
+
+    /**
+     * Sets the command entered to the given string and executes it
+     */
+    /**
+     * Handles the Enter button pressed event.
+     */
+    public void handleCommandEntered(String commandText) {
+        try {
+            commandExecutor.execute(commandText);
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();

--- a/src/main/java/seedu/resireg/ui/MainWindow.java
+++ b/src/main/java/seedu/resireg/ui/MainWindow.java
@@ -8,8 +8,6 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.TextInputControl;
-import javafx.scene.input.KeyCode;
-import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;

--- a/src/main/java/seedu/resireg/ui/MainWindow.java
+++ b/src/main/java/seedu/resireg/ui/MainWindow.java
@@ -8,6 +8,8 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.TextInputControl;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -4,6 +4,6 @@
 <?import javafx.scene.layout.StackPane?>
 
 <StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
+  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" onKeyPressed="#handleOnKeyPressed" promptText="Enter command here..."/>
 </StackPane>
 

--- a/src/test/java/seedu/resireg/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/resireg/logic/LogicManagerTest.java
@@ -85,6 +85,7 @@ public class LogicManagerTest {
         Student expectedStudent = new StudentBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addStudent(expectedStudent);
+        expectedModel.saveStateResiReg();
         String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/resireg/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/AddCommandIntegrationTest.java
@@ -31,6 +31,7 @@ public class AddCommandIntegrationTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addStudent(validStudent);
+        expectedModel.saveStateResiReg();
 
         assertCommandSuccess(new AddCommand(validStudent), model,
                 String.format(AddCommand.MESSAGE_SUCCESS, validStudent.getName().fullName,

--- a/src/test/java/seedu/resireg/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/AddCommandTest.java
@@ -169,6 +169,31 @@ public class AddCommandTest {
         public void updateFilteredRoomList(Predicate<Room> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public boolean canUndoResiReg() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean canRedoResiReg() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void undoResiReg() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void redoResiReg() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void saveStateResiReg() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**
@@ -205,6 +230,11 @@ public class AddCommandTest {
         public void addStudent(Student student) {
             requireNonNull(student);
             studentsAdded.add(student);
+        }
+
+        @Override
+        public void saveStateResiReg() {
+            // called by {@code AddCommand#execute()}
         }
 
         @Override

--- a/src/test/java/seedu/resireg/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/ClearCommandTest.java
@@ -16,6 +16,7 @@ public class ClearCommandTest {
     public void execute_emptyAddressBook_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
+        expectedModel.saveStateResiReg();
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
@@ -25,6 +26,7 @@ public class ClearCommandTest {
         Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel.setAddressBook(new AddressBook());
+        expectedModel.saveStateResiReg();
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }

--- a/src/test/java/seedu/resireg/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/DeleteCommandTest.java
@@ -35,6 +35,7 @@ public class DeleteCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteStudent(studentToDelete);
+        expectedModel.saveStateResiReg();
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
@@ -58,6 +59,7 @@ public class DeleteCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteStudent(studentToDelete);
+        expectedModel.saveStateResiReg();
         showNoStudent(expectedModel);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/resireg/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/EditCommandTest.java
@@ -44,6 +44,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setStudent(model.getFilteredStudentList().get(0), editedStudent);
+        expectedModel.saveStateResiReg();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -65,6 +66,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setStudent(lastStudent, editedStudent);
+        expectedModel.saveStateResiReg();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -77,6 +79,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedStudent);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.saveStateResiReg();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -94,6 +97,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setStudent(model.getFilteredStudentList().get(0), editedStudent);
+        expectedModel.saveStateResiReg();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }


### PR DESCRIPTION
This PR adds the functionality increment of the ability to `undo` and `redo` commands in ResiReg. These abilities are assigned the keyboard shortcuts "ctrl-z" and "ctrl-y" respectively. 

For now keyboard shortcuts are hardcoded as constants in the `CommandBox` class since there are few shortcuts to begin with, but in the future a `KeyboardCommandMapper` class that behaves similar to the `CommandMapper` class can be considered especially if a lot of keyboard shortcuts are to be added.

A new `CreateEditCopy` class which contains methods for "copy-constructing" Student and Room instances have been created for the time being to deal with persistence issues that inhibit the functionality of `undo` and `redo` under `allocate` and `deallocate` due to mutability.

Part of #31 and #33

### How to test
1. Checkout the branch
2. Run the main application
3. Type in a few commands
4. Type `undo` or `redo` in the command box for undoing and redoing commands respectively. (Alternatively, you can press ctrl-z or ctrl-y). 

### Notes:
1. To add testing support for newly added classes such as `VersionedResiReg`
2. To add additional tests for commands that affect state (e.g. `AddCommand` and `ClearCommmand`) to include interaction behaviour with undo and redo functionality
3. To change instances of `AddressBook` to `ResiReg`
