### PR TITLE
Add Aliasing support to ResiReg

### DIFF
--- a/src/main/java/seedu/resireg/Main.java
+++ b/src/main/java/seedu/resireg/Main.java
@@ -8,7 +8,7 @@ import javafx.application.Application;
  * This is a workaround for the following error when MainApp is made the
  * entry point of the application:
  *
- *     Error: JavaFX runtime components are missing, and are required to run this application
+ *     Error: JavaFX's runtime components are missing, and are required to run this application
  *
  * The reason is that MainApp extends Application. In that case, the
  * LauncherHelper will check for the javafx.graphics module to be present

--- a/src/main/java/seedu/resireg/commons/core/Messages.java
+++ b/src/main/java/seedu/resireg/commons/core/Messages.java
@@ -10,5 +10,4 @@ public class Messages {
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The student index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d students listed!";
     public static final String MESSAGE_INVALID_ROOM_DISPLAYED_INDEX = "The room index provided is invalid";
-
 }

--- a/src/main/java/seedu/resireg/logic/CommandMapper.java
+++ b/src/main/java/seedu/resireg/logic/CommandMapper.java
@@ -2,35 +2,41 @@ package seedu.resireg.logic;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import seedu.resireg.logic.commands.AddAliasCommand;
 import seedu.resireg.logic.commands.AddCommand;
 import seedu.resireg.logic.commands.AllocateCommand;
 import seedu.resireg.logic.commands.ClearCommand;
 import seedu.resireg.logic.commands.Command;
-import seedu.resireg.logic.commands.CommandWordEnum;
 import seedu.resireg.logic.commands.DeallocateCommand;
+import seedu.resireg.logic.commands.DeleteAliasCommand;
 import seedu.resireg.logic.commands.DeleteCommand;
 import seedu.resireg.logic.commands.EditCommand;
 import seedu.resireg.logic.commands.ExitCommand;
 import seedu.resireg.logic.commands.FindCommand;
 import seedu.resireg.logic.commands.Help;
 import seedu.resireg.logic.commands.HelpCommand;
+import seedu.resireg.logic.commands.ListAliasCommand;
 import seedu.resireg.logic.commands.ListCommand;
 import seedu.resireg.logic.commands.ListRoomCommand;
 import seedu.resireg.logic.commands.ReallocateCommand;
 import seedu.resireg.logic.commands.RedoCommand;
 import seedu.resireg.logic.commands.UndoCommand;
+import seedu.resireg.logic.parser.AddAliasCommandParser;
 import seedu.resireg.logic.parser.AddCommandParser;
 import seedu.resireg.logic.parser.AddressBookParser;
 import seedu.resireg.logic.parser.AllocateCommandParser;
 import seedu.resireg.logic.parser.DeallocateCommandParser;
+import seedu.resireg.logic.parser.DeleteAliasCommandParser;
 import seedu.resireg.logic.parser.DeleteCommandParser;
 import seedu.resireg.logic.parser.EditCommandParser;
 import seedu.resireg.logic.parser.FindCommandParser;
 import seedu.resireg.logic.parser.ListRoomCommandParser;
 import seedu.resireg.logic.parser.Parser;
 import seedu.resireg.logic.parser.ReallocateCommandParser;
+import seedu.resireg.model.alias.CommandWordAlias;
 
 /**
  * Manages the mapping between command words and parsers, and command words and their help messages.
@@ -47,7 +53,7 @@ public class CommandMapper {
      * Creates a new CommandMapper with all the commands supported by the application bound appropriately.
      * Developers who want to add new commands need to modify this constructor.
      */
-    public CommandMapper() {
+    public CommandMapper(List<CommandWordAlias> aliases) {
         commandMap = new CommandMap();
         // note: new Parser()::parse assumes that Parser does not depend on state
         commandMap.addCommand(AddCommand.COMMAND_WORD, AddCommand.HELP, new AddCommandParser()::parse);
@@ -66,6 +72,17 @@ public class CommandMapper {
             new ReallocateCommandParser()::parse);
         commandMap.addCommand(RedoCommand.COMMAND_WORD, RedoCommand.HELP, unused -> new RedoCommand());
         commandMap.addCommand(UndoCommand.COMMAND_WORD, UndoCommand.HELP, unused -> new UndoCommand());
+        commandMap.addCommand(AddAliasCommand.COMMAND_WORD, AddAliasCommand.HELP, new AddAliasCommandParser()::parse);
+        commandMap.addCommand(DeleteAliasCommand.COMMAND_WORD, DeleteAliasCommand.HELP,
+            new DeleteAliasCommandParser()::parse);
+        commandMap.addCommand(ListAliasCommand.COMMAND_WORD, ListAliasCommand.HELP, unused -> new ListAliasCommand());
+
+
+
+        for (CommandWordAlias commandWordAlias : aliases) {
+            commandMap.addAliasCommand(commandWordAlias.getAlias().toString(),
+                commandWordAlias.getCommandWord().toString());
+        }
 
         parser = new AddressBookParser(commandMap.getCommandWordToParserMap());
     }
@@ -80,11 +97,7 @@ public class CommandMapper {
      *
      * @return Parser.
      */
-    AddressBookParser getParser(Map<String, String> aliasWordMap) {
-        for(String alias : aliasWordMap.keySet()) {
-            String commandWord = aliasWordMap.get(alias);
-            commandMap.addAliasCommand(alias, commandWord);
-        }
+    AddressBookParser getParser() {
         return parser;
     }
 
@@ -98,13 +111,13 @@ public class CommandMapper {
         }
 
         void addCommand(String commandWord, Help help, Parser<Command> parser) {
-            commandWordToHelp.put(commandWord, parser);
-            commandWordToParser.put(command.getCommandWord(), command.getCommandParser());
+            commandWordToHelp.put(commandWord, help);
+            commandWordToParser.put(commandWord, parser);
         }
 
         void addAliasCommand(String alias, String commandWord) {
-            commandWordToHelp.put(commandWord, commandWordToHelp.get(commandWord));
-            commandWordToParser.put(commandWord, commandWordToParser.get(commandWord));
+            commandWordToHelp.put(alias, commandWordToHelp.get(commandWord));
+            commandWordToParser.put(alias, commandWordToParser.get(commandWord));
         }
 
         Map<String, Help> getCommandWordToHelpMap() {

--- a/src/main/java/seedu/resireg/logic/CommandMapper.java
+++ b/src/main/java/seedu/resireg/logic/CommandMapper.java
@@ -8,6 +8,7 @@ import seedu.resireg.logic.commands.AddCommand;
 import seedu.resireg.logic.commands.AllocateCommand;
 import seedu.resireg.logic.commands.ClearCommand;
 import seedu.resireg.logic.commands.Command;
+import seedu.resireg.logic.commands.CommandWordEnum;
 import seedu.resireg.logic.commands.DeallocateCommand;
 import seedu.resireg.logic.commands.DeleteCommand;
 import seedu.resireg.logic.commands.EditCommand;
@@ -60,9 +61,9 @@ public class CommandMapper {
         commandMap.addCommand(ListRoomCommand.COMMAND_WORD, ListRoomCommand.HELP, new ListRoomCommandParser()::parse);
         commandMap.addCommand(AllocateCommand.COMMAND_WORD, AllocateCommand.HELP, new AllocateCommandParser()::parse);
         commandMap.addCommand(DeallocateCommand.COMMAND_WORD, DeallocateCommand.HELP,
-                new DeallocateCommandParser()::parse);
+            new DeallocateCommandParser()::parse);
         commandMap.addCommand(ReallocateCommand.COMMAND_WORD, ReallocateCommand.HELP,
-                new ReallocateCommandParser()::parse);
+            new ReallocateCommandParser()::parse);
         commandMap.addCommand(RedoCommand.COMMAND_WORD, RedoCommand.HELP, unused -> new RedoCommand());
         commandMap.addCommand(UndoCommand.COMMAND_WORD, UndoCommand.HELP, unused -> new UndoCommand());
 
@@ -73,12 +74,17 @@ public class CommandMapper {
         return commandMap.getCommandWordToHelpMap();
     }
 
+
     /**
      * Returns a parser which parses user inputs and returns the appropriate Command.
      *
      * @return Parser.
      */
-    AddressBookParser getParser() {
+    AddressBookParser getParser(Map<String, String> aliasWordMap) {
+        for(String alias : aliasWordMap.keySet()) {
+            String commandWord = aliasWordMap.get(alias);
+            commandMap.addAliasCommand(alias, commandWord);
+        }
         return parser;
     }
 
@@ -92,8 +98,13 @@ public class CommandMapper {
         }
 
         void addCommand(String commandWord, Help help, Parser<Command> parser) {
-            commandWordToHelp.put(commandWord, help);
-            commandWordToParser.put(commandWord, parser);
+            commandWordToHelp.put(commandWord, parser);
+            commandWordToParser.put(command.getCommandWord(), command.getCommandParser());
+        }
+
+        void addAliasCommand(String alias, String commandWord) {
+            commandWordToHelp.put(commandWord, commandWordToHelp.get(commandWord));
+            commandWordToParser.put(commandWord, commandWordToParser.get(commandWord));
         }
 
         Map<String, Help> getCommandWordToHelpMap() {

--- a/src/main/java/seedu/resireg/logic/LogicManager.java
+++ b/src/main/java/seedu/resireg/logic/LogicManager.java
@@ -43,7 +43,7 @@ public class LogicManager implements Logic {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
-        addressBookParser = new CommandMapper(model.getAliasWordMap()).getParser();
+        addressBookParser = new CommandMapper(model.getCommandWordAliases()).getParser();
         Command command = addressBookParser.parseCommand(commandText);
         commandResult = command.execute(model);
 

--- a/src/main/java/seedu/resireg/logic/LogicManager.java
+++ b/src/main/java/seedu/resireg/logic/LogicManager.java
@@ -28,7 +28,7 @@ public class LogicManager implements Logic {
 
     private final Model model;
     private final Storage storage;
-    private final AddressBookParser addressBookParser;
+    private AddressBookParser addressBookParser; // mutable, to allow for dynamic aliasing
 
     /**
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
@@ -36,7 +36,6 @@ public class LogicManager implements Logic {
     public LogicManager(Model model, Storage storage) {
         this.model = model;
         this.storage = storage;
-        addressBookParser = new CommandMapper().getParser();
     }
 
     @Override
@@ -44,11 +43,13 @@ public class LogicManager implements Logic {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
+        addressBookParser = new CommandMapper(model.getAliasWordMap()).getParser();
         Command command = addressBookParser.parseCommand(commandText);
         commandResult = command.execute(model);
 
         try {
             storage.saveAddressBook(model.getAddressBook());
+            storage.saveUserPrefs(model.getUserPrefs());
         } catch (IOException ioe) {
             throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
         }

--- a/src/main/java/seedu/resireg/logic/commands/AddAliasCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/AddAliasCommand.java
@@ -1,0 +1,55 @@
+package seedu.resireg.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_ALIAS;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_COMMAND;
+
+import seedu.resireg.logic.commands.exceptions.CommandException;
+import seedu.resireg.model.Model;
+import seedu.resireg.model.alias.CommandWordAlias;
+
+/**
+ * Adds a student to the address book.
+ */
+public class AddAliasCommand extends Command {
+
+    public static final String COMMAND_WORD = CommandWordEnum.ADD_ALIAS_COMMAND.toString();
+
+    public static final String MESSAGE_SUCCESS = "New alias added: %1$s";
+    public static final String MESSAGE_DUPLICATE_ALIAS = "This alias already exists in ResiReg";
+
+    public static final Help HELP = new Help(COMMAND_WORD,
+        "Adds an alias to ResiReg.\n",
+        "Parameters: "
+            + PREFIX_COMMAND + "COMMAND "
+            + PREFIX_ALIAS + "ALIAS ");
+
+    private final CommandWordAlias toAdd;
+
+    /**
+     * Creates an AddCommand to add the specified {@code Student}
+     */
+    public AddAliasCommand(CommandWordAlias alias) {
+        requireNonNull(alias);
+        toAdd = alias;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (model.hasAlias(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_ALIAS);
+        }
+
+        model.addAlias(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof AddAliasCommand // instanceof handles nulls
+            && toAdd.equals(((AddAliasCommand) other).toAdd));
+    }
+}

--- a/src/main/java/seedu/resireg/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/AddCommand.java
@@ -17,7 +17,7 @@ import seedu.resireg.model.student.Student;
  */
 public class AddCommand extends Command {
 
-    public static final String COMMAND_WORD = "add";
+    public static final String COMMAND_WORD = CommandWordEnum.ADD_COMMAND.toString();
 
     public static final String MESSAGE_SUCCESS = "New student added: %1$s (%2$s)";
     public static final String MESSAGE_DUPLICATE_PERSON = "This student already exists in the address book";

--- a/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
@@ -21,7 +21,7 @@ import seedu.resireg.model.student.Student;
  */
 public class AllocateCommand extends Command {
 
-    public static final String COMMAND_WORD = "allocate";
+    public static final String COMMAND_WORD = CommandWordEnum.ALLOCATE_COMMAND.toString();
     public static final Help HELP = new Help(COMMAND_WORD,
             "Allocates a student to a room.",
             "Parameters: "

--- a/src/main/java/seedu/resireg/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ClearCommand.java
@@ -10,7 +10,7 @@ import seedu.resireg.model.Model;
  */
 public class ClearCommand extends Command {
 
-    public static final String COMMAND_WORD = "clear";
+    public static final String COMMAND_WORD = CommandWordEnum.CLEAR_COMMAND.toString();
     public static final String MESSAGE_SUCCESS = "ResiReg has been cleared!";
 
     public static final Help HELP = new Help(COMMAND_WORD, "Clears all students and rooms.");

--- a/src/main/java/seedu/resireg/logic/commands/CommandWordEnum.java
+++ b/src/main/java/seedu/resireg/logic/commands/CommandWordEnum.java
@@ -15,7 +15,9 @@ public enum CommandWordEnum {
     REALLOCATE_COMMAND("reallocate"),
     REDO_COMMAND("redo"),
     UNDO_COMMAND("undo"),
-    ADD_ALIAS_COMMAND("alias");
+    ADD_ALIAS_COMMAND("alias"),
+    DELETE_ALIAS_COMMAND("dealias"),
+    LIST_ALIAS_COMMAND("aliases");
 
     private String commandWord;
 

--- a/src/main/java/seedu/resireg/logic/commands/CommandWordEnum.java
+++ b/src/main/java/seedu/resireg/logic/commands/CommandWordEnum.java
@@ -1,0 +1,30 @@
+package seedu.resireg.logic.commands;
+
+public enum CommandWordEnum {
+    ADD_COMMAND("add"),
+    CLEAR_COMMAND("clear"),
+    DELETE_COMMAND("delete"),
+    EDIT_COMMAND("edit"),
+    EXIT_COMMAND("exit"),
+    FIND_COMMAND("find"),
+    HELP_COMMAND("help"),
+    LIST_COMMAND("students"),
+    LIST_ROOM_COMMAND("rooms"),
+    ALLOCATE_COMMAND("allocate"),
+    DEALLOCATE_COMMAND("deallocate"),
+    REALLOCATE_COMMAND("reallocate"),
+    REDO_COMMAND("redo"),
+    UNDO_COMMAND("undo"),
+    ADD_ALIAS_COMMAND("alias");
+
+    private String commandWord;
+
+
+    CommandWordEnum(String commandWord) {
+        this.commandWord = commandWord;
+    }
+
+    public String toString() {
+        return commandWord;
+    }
+}

--- a/src/main/java/seedu/resireg/logic/commands/DeallocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/DeallocateCommand.java
@@ -18,7 +18,7 @@ import seedu.resireg.model.student.Student;
  */
 public class DeallocateCommand extends Command {
 
-    public static final String COMMAND_WORD = "deallocate";
+    public static final String COMMAND_WORD = CommandWordEnum.DEALLOCATE_COMMAND.toString();
 
     public static final Help HELP = new Help(COMMAND_WORD, "Deallocates a student from a room.",
             "Parameters: " + PREFIX_STUDENT_INDEX + "STUDENT INDEX\n"

--- a/src/main/java/seedu/resireg/logic/commands/DeleteAliasCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/DeleteAliasCommand.java
@@ -19,7 +19,7 @@ public class DeleteAliasCommand extends Command {
     public static final String MESSAGE_INVALID_ALIAS = "This alias doesn't exist.";
 
     public static final Help HELP = new Help(COMMAND_WORD,
-        "Adds an alias to ResiReg.\n",
+        "Deletes an alias from ResiReg.\n",
         "Parameters: "
             + PREFIX_COMMAND + "COMMAND "
             + PREFIX_ALIAS + "ALIAS ");

--- a/src/main/java/seedu/resireg/logic/commands/DeleteAliasCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/DeleteAliasCommand.java
@@ -11,12 +11,12 @@ import seedu.resireg.model.alias.CommandWordAlias;
 /**
  * Adds a student to the address book.
  */
-public class AddAliasCommand extends Command {
+public class DeleteAliasCommand extends Command {
 
-    public static final String COMMAND_WORD = CommandWordEnum.ADD_ALIAS_COMMAND.toString();
+    public static final String COMMAND_WORD = CommandWordEnum.DELETE_ALIAS_COMMAND.toString();
 
-    public static final String MESSAGE_SUCCESS = "New alias added: %1$s";
-    public static final String MESSAGE_DUPLICATE_ALIAS = "This alias already exists in ResiReg";
+    public static final String MESSAGE_SUCCESS = "The alias %1$s has been deleted.";
+    public static final String MESSAGE_INVALID_ALIAS = "This alias doesn't exist.";
 
     public static final Help HELP = new Help(COMMAND_WORD,
         "Adds an alias to ResiReg.\n",
@@ -24,32 +24,33 @@ public class AddAliasCommand extends Command {
             + PREFIX_COMMAND + "COMMAND "
             + PREFIX_ALIAS + "ALIAS ");
 
-    private final CommandWordAlias toAdd;
+    private final CommandWordAlias toDelete;
 
     /**
      * Creates an AddCommand to add the specified {@code Student}
      */
-    public AddAliasCommand(CommandWordAlias alias) {
+    public DeleteAliasCommand(CommandWordAlias alias) {
         requireNonNull(alias);
-        toAdd = alias;
+        toDelete = alias;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasCommandWordAlias(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_ALIAS);
+        if (!model.hasCommandWordAlias(toDelete)) {
+            throw new CommandException(MESSAGE_INVALID_ALIAS);
         }
 
-        model.addCommandWordAlias(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        model.deleteCommandWordAlias(toDelete);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toDelete));
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-            || (other instanceof AddAliasCommand // instanceof handles nulls
-            && toAdd.equals(((AddAliasCommand) other).toAdd));
+            || (other instanceof DeleteAliasCommand // instanceof handles nulls
+            && toDelete.equals(((DeleteAliasCommand) other).toDelete));
     }
 }
+

--- a/src/main/java/seedu/resireg/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/DeleteCommand.java
@@ -16,7 +16,7 @@ import seedu.resireg.model.student.Student;
  */
 public class DeleteCommand extends Command {
 
-    public static final String COMMAND_WORD = "delete";
+    public static final String COMMAND_WORD = CommandWordEnum.DELETE_COMMAND.toString();
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Student: %1$s";
     public static final String MESSAGE_ROOM_ALLOCATION_EXISTS =

--- a/src/main/java/seedu/resireg/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/EditCommand.java
@@ -35,7 +35,7 @@ import seedu.resireg.model.tag.Tag;
  */
 public class EditCommand extends Command {
 
-    public static final String COMMAND_WORD = "edit";
+    public static final String COMMAND_WORD = CommandWordEnum.EDIT_COMMAND.toString();
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Student: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/resireg/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ExitCommand.java
@@ -7,7 +7,7 @@ import seedu.resireg.model.Model;
  */
 public class ExitCommand extends Command {
 
-    public static final String COMMAND_WORD = "exit";
+    public static final String COMMAND_WORD = CommandWordEnum.EXIT_COMMAND.toString();
 
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
 

--- a/src/main/java/seedu/resireg/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/FindCommand.java
@@ -12,7 +12,7 @@ import seedu.resireg.model.student.NameContainsKeywordsPredicate;
  */
 public class FindCommand extends Command {
 
-    public static final String COMMAND_WORD = "find";
+    public static final String COMMAND_WORD = CommandWordEnum.FIND_COMMAND.toString();
 
     public static final Help HELP = new Help(COMMAND_WORD,
             "Finds all students whose names contain any of the specified keywords (case-insensitive) and displays"

--- a/src/main/java/seedu/resireg/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/HelpCommand.java
@@ -1,5 +1,6 @@
 package seedu.resireg.logic.commands;
 
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -24,7 +25,7 @@ public class HelpCommand extends Command {
 
     public static final String MESSAGE_GENERAL_HELP = "Commands available:\n"
             // summary for commands available (excluding help command), in alphabetical order
-            + new CommandMapper().getCommandWordToHelpMap().entrySet().stream()
+            + new CommandMapper(new ArrayList<>()).getCommandWordToHelpMap().entrySet().stream()
                     .sorted(Map.Entry.comparingByKey())
                     .filter(entry -> !entry.getKey().equals(HelpCommand.COMMAND_WORD))
                     .map(entry -> entry.getValue().getSummary())
@@ -35,7 +36,7 @@ public class HelpCommand extends Command {
             + "You can also refer to our user guide at: https://ay2021s1-cs2103-t16-3.github.io/tp/UserGuide.html";
 
     private static final Map<String, Help> commandWordToHelpMap =
-            new CommandMapper().getCommandWordToHelpMap();
+            new CommandMapper(new ArrayList<>()).getCommandWordToHelpMap();
 
     private String input;
 

--- a/src/main/java/seedu/resireg/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/HelpCommand.java
@@ -13,7 +13,7 @@ import seedu.resireg.model.Model;
  */
 public class HelpCommand extends Command {
 
-    public static final String COMMAND_WORD = "help";
+    public static final String COMMAND_WORD = CommandWordEnum.HELP_COMMAND.toString();
 
     public static final Help HELP = new Help(COMMAND_WORD,
             "Gets help for a command or ResiReg in general.",

--- a/src/main/java/seedu/resireg/logic/commands/ListAliasCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ListAliasCommand.java
@@ -1,0 +1,29 @@
+package seedu.resireg.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.resireg.model.Model;
+
+/**
+ * Lists all students in the address book to the user.
+ */
+public class ListAliasCommand extends Command {
+
+    public static final String COMMAND_WORD = CommandWordEnum.LIST_ALIAS_COMMAND.toString();
+
+    public static final String MESSAGE_SUCCESS = "Here are the command-alias pairs defined so far: \n%1$s";
+    public static final String MESSAGE_EMPTY_ALIAS = "No command-alias pairs have been defined so far.";
+
+
+    public static final Help HELP = new Help(COMMAND_WORD, "Lists all command-alias pairs.");
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        if(model.getCommandWordAliases().isEmpty()) {
+            return new CommandResult(MESSAGE_EMPTY_ALIAS);
+        }
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, model.getCommandWordAliasesAsString()));
+    }
+}

--- a/src/main/java/seedu/resireg/logic/commands/ListAliasCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ListAliasCommand.java
@@ -20,7 +20,7 @@ public class ListAliasCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        if(model.getCommandWordAliases().isEmpty()) {
+        if (model.getCommandWordAliases().isEmpty()) {
             return new CommandResult(MESSAGE_EMPTY_ALIAS);
         }
 

--- a/src/main/java/seedu/resireg/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ListCommand.java
@@ -10,7 +10,7 @@ import seedu.resireg.model.Model;
  */
 public class ListCommand extends Command {
 
-    public static final String COMMAND_WORD = "students";
+    public static final String COMMAND_WORD = CommandWordEnum.LIST_COMMAND.toString();
 
     public static final String MESSAGE_SUCCESS = "Listed all students";
 

--- a/src/main/java/seedu/resireg/logic/commands/ListRoomCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ListRoomCommand.java
@@ -8,7 +8,7 @@ import seedu.resireg.model.Model;
  * Lists all rooms in the address book to the user.
  */
 public class ListRoomCommand extends Command {
-    public static final String COMMAND_WORD = "rooms";
+    public static final String COMMAND_WORD = CommandWordEnum.LIST_ROOM_COMMAND.toString();
     public static final String COMMAND_VACANT_FLAG = "vacant";
     public static final String COMMAND_ALLOCATED_FLAG = "allocated";
 

--- a/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
@@ -20,7 +20,7 @@ import seedu.resireg.model.student.Student;
  */
 public class ReallocateCommand extends Command {
 
-    public static final String COMMAND_WORD = "reallocate";
+    public static final String COMMAND_WORD = CommandWordEnum.REALLOCATE_COMMAND.toString();
     public static final Help HELP = new Help(COMMAND_WORD, "Reallocates a student to a room.",
             "Parameters: " + PREFIX_STUDENT_INDEX + "STUDENT INDEX " + PREFIX_ROOM_INDEX + "ROOM INDEX\n"
                     + "Example: " + COMMAND_WORD + " " + PREFIX_STUDENT_INDEX + "1 " + PREFIX_ROOM_INDEX + "1");

--- a/src/main/java/seedu/resireg/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/RedoCommand.java
@@ -15,7 +15,7 @@ public class RedoCommand extends Command {
     public static final String COMMAND_WORD = CommandWordEnum.REDO_COMMAND.toString();
 
     public static final String MESSAGE_SUCCESS = "Redo success!";
-    public static final String MESSAGE_FAILURE = "No more commands to redo!";
+    public static final String MESSAGE_FAILURE = "No more actions to redo!";
 
     public static final Help HELP = new Help(COMMAND_WORD, "Redo a previous command.");
 

--- a/src/main/java/seedu/resireg/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/RedoCommand.java
@@ -12,7 +12,7 @@ import seedu.resireg.model.Model;
  */
 public class RedoCommand extends Command {
 
-    public static final String COMMAND_WORD = "redo";
+    public static final String COMMAND_WORD = CommandWordEnum.REDO_COMMAND.toString();
 
     public static final String MESSAGE_SUCCESS = "Redo success!";
     public static final String MESSAGE_FAILURE = "No more commands to redo!";

--- a/src/main/java/seedu/resireg/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/UndoCommand.java
@@ -14,7 +14,7 @@ public class UndoCommand extends Command {
     public static final String COMMAND_WORD = CommandWordEnum.UNDO_COMMAND.toString();
 
     public static final String MESSAGE_SUCCESS = "Undo success!";
-    public static final String MESSAGE_FAILURE = "No more commands to undo!";
+    public static final String MESSAGE_FAILURE = "No more actions to undo!";
 
     public static final Help HELP = new Help(COMMAND_WORD, "Undo a previous command");
 

--- a/src/main/java/seedu/resireg/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/UndoCommand.java
@@ -11,7 +11,7 @@ import seedu.resireg.model.Model;
  * Reverts the {@code model}'s ResiReg to its previous state.
  */
 public class UndoCommand extends Command {
-    public static final String COMMAND_WORD = "undo";
+    public static final String COMMAND_WORD = CommandWordEnum.UNDO_COMMAND.toString();
 
     public static final String MESSAGE_SUCCESS = "Undo success!";
     public static final String MESSAGE_FAILURE = "No more commands to undo!";

--- a/src/main/java/seedu/resireg/logic/parser/AddAliasCommandParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/AddAliasCommandParser.java
@@ -1,0 +1,50 @@
+package seedu.resireg.logic.parser;
+
+import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_ALIAS;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_COMMAND;
+
+import java.util.stream.Stream;
+
+import seedu.resireg.logic.commands.AddAliasCommand;
+import seedu.resireg.logic.parser.exceptions.ParseException;
+import seedu.resireg.model.alias.Alias;
+import seedu.resireg.model.alias.CommandWord;
+import seedu.resireg.model.alias.CommandWordAlias;
+
+/**
+ * Parses input arguments and creates a new AddCommand object
+ */
+public class AddAliasCommandParser implements Parser<AddAliasCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand
+     * and returns an AddCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddAliasCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+            ArgumentTokenizer.tokenize(args, PREFIX_COMMAND, PREFIX_ALIAS);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_COMMAND, PREFIX_ALIAS)
+            || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddAliasCommand.HELP.getFullMessage()));
+        }
+
+        CommandWord commandWord = ParserUtil.parseCommandWord(argMultimap.getValue(PREFIX_COMMAND).get());
+        Alias alias = ParserUtil.parseAlias(argMultimap.getValue(PREFIX_ALIAS).get());
+
+        CommandWordAlias commandWordAlias = new CommandWordAlias(commandWord, alias);
+
+        return new AddAliasCommand(commandWordAlias);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/resireg/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/resireg/logic/parser/CliSyntax.java
@@ -14,4 +14,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_STUDENT_INDEX = new Prefix("si/");
     public static final Prefix PREFIX_ROOM_INDEX = new Prefix("ri/");
+    public static final Prefix PREFIX_COMMAND = new Prefix("c/");
+    public static final Prefix PREFIX_ALIAS = new Prefix("a/");
+
 }

--- a/src/main/java/seedu/resireg/logic/parser/DeleteAliasCommandParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/DeleteAliasCommandParser.java
@@ -6,7 +6,6 @@ import static seedu.resireg.logic.parser.CliSyntax.PREFIX_COMMAND;
 
 import java.util.stream.Stream;
 
-import seedu.resireg.logic.commands.AddAliasCommand;
 import seedu.resireg.logic.commands.DeleteAliasCommand;
 import seedu.resireg.logic.parser.exceptions.ParseException;
 import seedu.resireg.model.alias.Alias;
@@ -30,7 +29,7 @@ public class DeleteAliasCommandParser implements Parser<DeleteAliasCommand> {
         if (!arePrefixesPresent(argMultimap, PREFIX_COMMAND, PREFIX_ALIAS)
             || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                AddAliasCommand.HELP.getFullMessage()));
+                DeleteAliasCommand.HELP.getFullMessage()));
         }
 
         CommandWord commandWord = ParserUtil.parseCommandWord(argMultimap.getValue(PREFIX_COMMAND).get());

--- a/src/main/java/seedu/resireg/logic/parser/DeleteAliasCommandParser.java
+++ b/src/main/java/seedu/resireg/logic/parser/DeleteAliasCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.resireg.logic.parser.CliSyntax.PREFIX_COMMAND;
 import java.util.stream.Stream;
 
 import seedu.resireg.logic.commands.AddAliasCommand;
+import seedu.resireg.logic.commands.DeleteAliasCommand;
 import seedu.resireg.logic.parser.exceptions.ParseException;
 import seedu.resireg.model.alias.Alias;
 import seedu.resireg.model.alias.CommandWord;
@@ -15,14 +16,14 @@ import seedu.resireg.model.alias.CommandWordAlias;
 /**
  * Parses input arguments and creates a new AddCommand object
  */
-public class AddAliasCommandParser implements Parser<AddAliasCommand> {
+public class DeleteAliasCommandParser implements Parser<DeleteAliasCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public AddAliasCommand parse(String args) throws ParseException {
+    public DeleteAliasCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_COMMAND, PREFIX_ALIAS);
 
@@ -37,7 +38,7 @@ public class AddAliasCommandParser implements Parser<AddAliasCommand> {
 
         CommandWordAlias commandWordAlias = new CommandWordAlias(commandWord, alias);
 
-        return new AddAliasCommand(commandWordAlias);
+        return new DeleteAliasCommand(commandWordAlias);
     }
 
     /**

--- a/src/main/java/seedu/resireg/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/resireg/logic/parser/ParserUtil.java
@@ -9,6 +9,8 @@ import java.util.Set;
 import seedu.resireg.commons.core.index.Index;
 import seedu.resireg.commons.util.StringUtil;
 import seedu.resireg.logic.parser.exceptions.ParseException;
+import seedu.resireg.model.alias.Alias;
+import seedu.resireg.model.alias.CommandWord;
 import seedu.resireg.model.room.Floor;
 import seedu.resireg.model.room.RoomNumber;
 import seedu.resireg.model.student.Email;
@@ -168,5 +170,35 @@ public class ParserUtil {
             throw new ParseException(RoomNumber.MESSAGE_CONSTRAINTS);
         }
         return new RoomNumber(trimmedRoomNumber);
+    }
+
+    /**
+     * Parses a {@code String commandWord} into a {@code CommandWord}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code commandWord} is invalid.
+     */
+    public static CommandWord parseCommandWord(String commandWord) throws ParseException {
+        requireNonNull(commandWord);
+        String trimmedCommandWord = commandWord.trim();
+        if (!CommandWord.isValidCommandWord(trimmedCommandWord)) {
+            throw new ParseException(CommandWord.MESSAGE_CONSTRAINTS);
+        }
+        return new CommandWord(trimmedCommandWord);
+    }
+
+    /**
+     * Parses a {@code String alias} into a {@code Alias}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code alias} is invalid.
+     */
+    public static Alias parseAlias(String alias) throws ParseException {
+        requireNonNull(alias);
+        String trimmedAlias = alias.trim();
+        if (!Alias.isValidAlias(trimmedAlias)) {
+            throw new ParseException(Alias.MESSAGE_CONSTRAINTS);
+        }
+        return new Alias(trimmedAlias);
     }
 }

--- a/src/main/java/seedu/resireg/model/Model.java
+++ b/src/main/java/seedu/resireg/model/Model.java
@@ -114,15 +114,24 @@ public interface Model {
      */
     void setStudent(Student target, Student editedStudent);
 
-    /**
-     * Returns true if an allocation with the {@code student} exists in the address book.
-     */
-    boolean isAllocated(Student student);
+    // === ROOMS ====
 
     /**
-     * Returns true if an allocation with the {@code room} exists in the address book.
+     * Returns true if a room with the same data as {@code room} exists in the address book.
      */
-    boolean isAllocated(Room room);
+    boolean hasRoom(Room room);
+
+    /**
+     * Deletes the given room.
+     * The room must exist in ResiReg.
+     */
+    void deleteRoom(Room target);
+
+    /**
+     * Adds the given room.
+     * {@code room} must already exist in ResiReg.
+     */
+    void addRoom(Room room);
 
     /**
      * Replaces the given room {@code target} with {@code editedRoom}.
@@ -132,10 +141,17 @@ public interface Model {
      */
     void setRoom(Room target, Room editedRoom);
 
+
+    // === ALLOCATIONS ====
     /**
-     * Returns true if a room with the same data as {@code room} exists in the address book.
+     * Returns true if an allocation with the {@code student} exists in the address book.
      */
-    boolean hasRoom(Room room);
+    boolean isAllocated(Student student);
+
+    /**
+     * Returns true if an allocation with the {@code room} exists in the address book.
+     */
+    boolean isAllocated(Room room);
 
     /**
      * Returns true if an allocation with the same identity as {@code allocation} exists in the address book.

--- a/src/main/java/seedu/resireg/model/Model.java
+++ b/src/main/java/seedu/resireg/model/Model.java
@@ -2,7 +2,6 @@ package seedu.resireg.model;
 
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -48,28 +47,29 @@ public interface Model {
     /**
      * Returns the user prefs' command aliases.
      */
-     Map<String, String> getAliasWordMap();
+    List<CommandWordAlias> getCommandWordAliases();
 
     /**
-     * Sets the user prefs' command aliases.
+     * Returns the user prefs' command aliases.
      */
-    void setCommandAliases(List<CommandWordAlias> commandAliases);
+    String getCommandWordAliasesAsString();
 
     /**
-     * Returns true if a command alias with the same data as {@code alias} exists in user preferences.
+     * Returns true if a command alias with the same data as {@code target} exists in user preferences.
      */
-    boolean hasAlias(CommandWordAlias target);
+    boolean hasCommandWordAlias(CommandWordAlias target);
+
     /**
      * Deletes the given alias.
      * The alias must exist in user prefs.
      */
-    void deleteAlias(CommandWordAlias target);
+    void deleteCommandWordAlias(CommandWordAlias target);
 
     /**
      * Adds the given alias.
      * {@code alias} must not already exist in user prefs.
      */
-    void addAlias(CommandWordAlias source);
+    void addCommandWordAlias(CommandWordAlias source);
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/resireg/model/Model.java
+++ b/src/main/java/seedu/resireg/model/Model.java
@@ -1,10 +1,13 @@
 package seedu.resireg.model;
 
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.resireg.commons.core.GuiSettings;
+import seedu.resireg.model.alias.CommandWordAlias;
 import seedu.resireg.model.allocation.Allocation;
 import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.Student;
@@ -41,6 +44,32 @@ public interface Model {
      * Sets the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Returns the user prefs' command aliases.
+     */
+     Map<String, String> getAliasWordMap();
+
+    /**
+     * Sets the user prefs' command aliases.
+     */
+    void setCommandAliases(List<CommandWordAlias> commandAliases);
+
+    /**
+     * Returns true if a command alias with the same data as {@code alias} exists in user preferences.
+     */
+    boolean hasAlias(CommandWordAlias target);
+    /**
+     * Deletes the given alias.
+     * The alias must exist in user prefs.
+     */
+    void deleteAlias(CommandWordAlias target);
+
+    /**
+     * Adds the given alias.
+     * {@code alias} must not already exist in user prefs.
+     */
+    void addAlias(CommandWordAlias source);
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/resireg/model/ModelManager.java
+++ b/src/main/java/seedu/resireg/model/ModelManager.java
@@ -86,6 +86,7 @@ public class ModelManager implements Model {
 
     @Override
     public boolean hasCommandWordAlias(CommandWordAlias target) {
+        requireNonNull(target);
         return userPrefs.hasAlias(target);
     }
 
@@ -123,6 +124,9 @@ public class ModelManager implements Model {
         return versionedResiReg;
     }
 
+
+    //=========== Student  ================================================================================
+
     @Override
     public boolean hasStudent(Student student) {
         requireNonNull(student);
@@ -147,6 +151,32 @@ public class ModelManager implements Model {
         versionedResiReg.setStudent(target, editedStudent);
     }
 
+    //=========== Room ================================================================================
+    @Override
+    public void setRoom(Room target, Room editedRoom) {
+        requireAllNonNull(target, editedRoom);
+        versionedResiReg.setRoom(target, editedRoom);
+    }
+
+    @Override
+    public boolean hasRoom(Room room) {
+        requireNonNull(room);
+        return versionedResiReg.hasRoom(room);
+    }
+
+    @Override
+    public void deleteRoom(Room target) {
+        versionedResiReg.removeRoom(target);
+    }
+
+    @Override
+    public void addRoom(Room room) {
+        requireNonNull(room);
+        versionedResiReg.addRoom(room);
+        updateFilteredRoomList(PREDICATE_SHOW_ALL_ROOMS);
+    }
+
+    //=========== Allocation ================================================================================
     @Override
     public boolean isAllocated(Student student) {
         requireNonNull(student);
@@ -160,18 +190,6 @@ public class ModelManager implements Model {
     public boolean isAllocated(Room room) {
         requireNonNull(room);
         return versionedResiReg.isAllocated(room);
-    }
-
-    @Override
-    public void setRoom(Room target, Room editedRoom) {
-        requireAllNonNull(target, editedRoom);
-        versionedResiReg.setRoom(target, editedRoom);
-    }
-
-    @Override
-    public boolean hasRoom(Room room) {
-        requireNonNull(room);
-        return versionedResiReg.hasRoom(room);
     }
 
     @Override

--- a/src/main/java/seedu/resireg/model/ModelManager.java
+++ b/src/main/java/seedu/resireg/model/ModelManager.java
@@ -4,9 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.resireg.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -76,28 +75,27 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public Map<String, String> getAliasWordMap() {
-        return userPrefs.getAliasWordMap();
+    public List<CommandWordAlias> getCommandWordAliases() {
+        return Collections.unmodifiableList(userPrefs.getCommandWordAliases());
     }
 
     @Override
-    public void setCommandAliases(List<CommandWordAlias> commandAliases) {
-        requireNonNull(commandAliases);
-        userPrefs.setCommandAliases(commandAliases);
+    public String getCommandWordAliasesAsString() {
+        return userPrefs.getCommandWordAliasesAsString();
     }
 
     @Override
-    public boolean hasAlias(CommandWordAlias target) {
+    public boolean hasCommandWordAlias(CommandWordAlias target) {
         return userPrefs.hasAlias(target);
     }
 
     @Override
-    public void deleteAlias(CommandWordAlias target) {
+    public void deleteCommandWordAlias(CommandWordAlias target) {
         userPrefs.deleteAlias(target);
     }
 
     @Override
-    public void addAlias(CommandWordAlias source) {
+    public void addCommandWordAlias(CommandWordAlias source) {
         requireNonNull(source);
         userPrefs.addAlias(source);
     }

--- a/src/main/java/seedu/resireg/model/ModelManager.java
+++ b/src/main/java/seedu/resireg/model/ModelManager.java
@@ -4,6 +4,9 @@ import static java.util.Objects.requireNonNull;
 import static seedu.resireg.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -11,6 +14,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.resireg.commons.core.GuiSettings;
 import seedu.resireg.commons.core.LogsCenter;
+import seedu.resireg.model.alias.CommandWordAlias;
 import seedu.resireg.model.allocation.Allocation;
 import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.Student;
@@ -69,6 +73,33 @@ public class ModelManager implements Model {
     public void setGuiSettings(GuiSettings guiSettings) {
         requireNonNull(guiSettings);
         userPrefs.setGuiSettings(guiSettings);
+    }
+
+    @Override
+    public Map<String, String> getAliasWordMap() {
+        return userPrefs.getAliasWordMap();
+    }
+
+    @Override
+    public void setCommandAliases(List<CommandWordAlias> commandAliases) {
+        requireNonNull(commandAliases);
+        userPrefs.setCommandAliases(commandAliases);
+    }
+
+    @Override
+    public boolean hasAlias(CommandWordAlias target) {
+        return userPrefs.hasAlias(target);
+    }
+
+    @Override
+    public void deleteAlias(CommandWordAlias target) {
+        userPrefs.deleteAlias(target);
+    }
+
+    @Override
+    public void addAlias(CommandWordAlias source) {
+        requireNonNull(source);
+        userPrefs.addAlias(source);
     }
 
     @Override

--- a/src/main/java/seedu/resireg/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/seedu/resireg/model/ReadOnlyUserPrefs.java
@@ -13,7 +13,7 @@ public interface ReadOnlyUserPrefs {
 
     GuiSettings getGuiSettings();
 
-    List<CommandWordAlias> getCommandAliases();
+    List<CommandWordAlias> getCommandWordAliases();
 
     Path getAddressBookFilePath();
 

--- a/src/main/java/seedu/resireg/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/seedu/resireg/model/ReadOnlyUserPrefs.java
@@ -1,8 +1,10 @@
 package seedu.resireg.model;
 
 import java.nio.file.Path;
+import java.util.List;
 
 import seedu.resireg.commons.core.GuiSettings;
+import seedu.resireg.model.alias.CommandWordAlias;
 
 /**
  * Unmodifiable view of user prefs.
@@ -10,6 +12,8 @@ import seedu.resireg.commons.core.GuiSettings;
 public interface ReadOnlyUserPrefs {
 
     GuiSettings getGuiSettings();
+
+    List<CommandWordAlias> getCommandAliases();
 
     Path getAddressBookFilePath();
 

--- a/src/main/java/seedu/resireg/model/UserPrefs.java
+++ b/src/main/java/seedu/resireg/model/UserPrefs.java
@@ -5,9 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import seedu.resireg.commons.core.GuiSettings;
@@ -19,7 +17,7 @@ import seedu.resireg.model.alias.CommandWordAlias;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
-    private List<CommandWordAlias> commandAliases = new ArrayList<>();
+    private List<CommandWordAlias> commandWordAliases = new ArrayList<>();
     private Path addressBookFilePath = Paths.get("data" , "addressbook.json");
 
     /**
@@ -41,7 +39,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     public void resetData(ReadOnlyUserPrefs newUserPrefs) {
         requireNonNull(newUserPrefs);
         setGuiSettings(newUserPrefs.getGuiSettings());
-        setCommandAliases(newUserPrefs.getCommandAliases());
+        setCommandAliases(newUserPrefs.getCommandWordAliases());
         setAddressBookFilePath(newUserPrefs.getAddressBookFilePath());
     }
 
@@ -54,36 +52,36 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         this.guiSettings = guiSettings;
     }
 
-    public List<CommandWordAlias> getCommandAliases() {
-        return commandAliases;
+    public List<CommandWordAlias> getCommandWordAliases() {
+        return commandWordAliases;
     }
 
-    public Map<String, String> getAliasWordMap() {
-        final Map<String, String> map = new HashMap<>();
-        for(CommandWordAlias commandWordAlias : getCommandAliases()) {
-            final String commandWord = commandWordAlias.getCommandWord().toString();
-            final String alias = commandWordAlias.getAlias().toString();
-            map.put(commandWord, alias);
-        }
-        return map;
+    /**
+     * Resets the existing commandAliases of this {@code UserPrefs} with new {@code commandAliases}.
+     */
+    public void setCommandAliases(List<CommandWordAlias> commandWordAliases) {
+        requireNonNull(commandWordAliases);
+        this.commandWordAliases = commandWordAliases;
     }
 
-    public void setCommandAliases(List<CommandWordAlias> commandAliases) {
-        requireNonNull(commandAliases);
-        this.commandAliases = commandAliases;
-    }
-
+    /**
+     * Checks whether the existing commandAliases of this {@code UserPrefs} contains the target object.
+     */
     public boolean hasAlias(CommandWordAlias target) {
-        return commandAliases.contains(target);
+        return commandWordAliases.stream().anyMatch(commandWordAlias ->
+            commandWordAlias.getAlias().equals(target.getAlias()));
     }
 
     public void deleteAlias(CommandWordAlias target) {
-        commandAliases.remove(target);
+        commandWordAliases.remove(target);
     }
 
+    /**
+     * Adds a new command word alias to the  existing commandAliases list of this {@code UserPrefs}
+     */
     public void addAlias(CommandWordAlias source) {
         requireNonNull(source);
-        commandAliases.add(source);
+        commandWordAliases.add(source);
     }
 
 
@@ -108,22 +106,29 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         UserPrefs o = (UserPrefs) other;
 
         return guiSettings.equals(o.guiSettings)
-                && commandAliases.equals(o.commandAliases)
+                && commandWordAliases.equals(o.commandWordAliases)
                 && addressBookFilePath.equals(o.addressBookFilePath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(guiSettings, commandAliases, addressBookFilePath);
+        return Objects.hash(guiSettings, commandWordAliases, addressBookFilePath);
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("Gui Settings : " + guiSettings);
-        sb.append("Command Aliases : " + commandAliases);
+        sb.append("Command Aliases : " + commandWordAliases);
         sb.append("\nLocal data file location : " + addressBookFilePath);
         return sb.toString();
     }
 
+    public String getCommandWordAliasesAsString() {
+        String res = "";
+        for(CommandWordAlias commandWordAlias : commandWordAliases) {
+            res = res + commandWordAlias.toString() + "\n";
+        }
+        return res;
+    }
 }

--- a/src/main/java/seedu/resireg/model/UserPrefs.java
+++ b/src/main/java/seedu/resireg/model/UserPrefs.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 
 import seedu.resireg.commons.core.GuiSettings;
 import seedu.resireg.model.alias.CommandWordAlias;
+import seedu.resireg.model.alias.exceptions.DuplicateCommandWordAliasException;
 
 /**
  * Represents User's preferences.
@@ -61,13 +62,17 @@ public class UserPrefs implements ReadOnlyUserPrefs {
      */
     public void setCommandAliases(List<CommandWordAlias> commandWordAliases) {
         requireNonNull(commandWordAliases);
-        this.commandWordAliases = commandWordAliases;
+        if (!aliasesAreUnique(commandWordAliases)) {
+            throw new DuplicateCommandWordAliasException();
+        }
+        this.commandWordAliases = new ArrayList<>(commandWordAliases);
     }
 
     /**
      * Checks whether the existing commandAliases of this {@code UserPrefs} contains the target object.
      */
     public boolean hasAlias(CommandWordAlias target) {
+        requireNonNull(target);
         return commandWordAliases.stream().anyMatch(commandWordAlias ->
             commandWordAlias.getAlias().equals(target.getAlias()));
     }
@@ -126,9 +131,23 @@ public class UserPrefs implements ReadOnlyUserPrefs {
 
     public String getCommandWordAliasesAsString() {
         String res = "";
-        for(CommandWordAlias commandWordAlias : commandWordAliases) {
+        for (CommandWordAlias commandWordAlias : commandWordAliases) {
             res = res + commandWordAlias.toString() + "\n";
         }
         return res;
+    }
+
+    /**
+     * Returns true if {@code commandAliases} contains only unique command word aliases.
+     */
+    private boolean aliasesAreUnique(List<CommandWordAlias> commandWordAliases) {
+        for (int i = 0; i < commandWordAliases.size() - 1; i++) {
+            for (int j = i + 1; j < commandWordAliases.size(); j++) {
+                if (commandWordAliases.get(i).equals(commandWordAliases.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/seedu/resireg/model/UserPrefs.java
+++ b/src/main/java/seedu/resireg/model/UserPrefs.java
@@ -4,9 +4,14 @@ import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import seedu.resireg.commons.core.GuiSettings;
+import seedu.resireg.model.alias.CommandWordAlias;
 
 /**
  * Represents User's preferences.
@@ -14,6 +19,7 @@ import seedu.resireg.commons.core.GuiSettings;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
+    private List<CommandWordAlias> commandAliases = new ArrayList<>();
     private Path addressBookFilePath = Paths.get("data" , "addressbook.json");
 
     /**
@@ -35,6 +41,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     public void resetData(ReadOnlyUserPrefs newUserPrefs) {
         requireNonNull(newUserPrefs);
         setGuiSettings(newUserPrefs.getGuiSettings());
+        setCommandAliases(newUserPrefs.getCommandAliases());
         setAddressBookFilePath(newUserPrefs.getAddressBookFilePath());
     }
 
@@ -46,6 +53,39 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         requireNonNull(guiSettings);
         this.guiSettings = guiSettings;
     }
+
+    public List<CommandWordAlias> getCommandAliases() {
+        return commandAliases;
+    }
+
+    public Map<String, String> getAliasWordMap() {
+        final Map<String, String> map = new HashMap<>();
+        for(CommandWordAlias commandWordAlias : getCommandAliases()) {
+            final String commandWord = commandWordAlias.getCommandWord().toString();
+            final String alias = commandWordAlias.getAlias().toString();
+            map.put(commandWord, alias);
+        }
+        return map;
+    }
+
+    public void setCommandAliases(List<CommandWordAlias> commandAliases) {
+        requireNonNull(commandAliases);
+        this.commandAliases = commandAliases;
+    }
+
+    public boolean hasAlias(CommandWordAlias target) {
+        return commandAliases.contains(target);
+    }
+
+    public void deleteAlias(CommandWordAlias target) {
+        commandAliases.remove(target);
+    }
+
+    public void addAlias(CommandWordAlias source) {
+        requireNonNull(source);
+        commandAliases.add(source);
+    }
+
 
     public Path getAddressBookFilePath() {
         return addressBookFilePath;
@@ -68,18 +108,20 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         UserPrefs o = (UserPrefs) other;
 
         return guiSettings.equals(o.guiSettings)
+                && commandAliases.equals(o.commandAliases)
                 && addressBookFilePath.equals(o.addressBookFilePath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(guiSettings, addressBookFilePath);
+        return Objects.hash(guiSettings, commandAliases, addressBookFilePath);
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("Gui Settings : " + guiSettings);
+        sb.append("Command Aliases : " + commandAliases);
         sb.append("\nLocal data file location : " + addressBookFilePath);
         return sb.toString();
     }

--- a/src/main/java/seedu/resireg/model/alias/Alias.java
+++ b/src/main/java/seedu/resireg/model/alias/Alias.java
@@ -10,13 +10,13 @@ import static seedu.resireg.commons.util.AppUtil.checkArgument;
 public class Alias {
 
     public static final String MESSAGE_CONSTRAINTS =
-        "Aliases should only contain alphanumeric characters and spaces, and it should not be a command word";
+        "Aliases should be single alphabetic words, and should not be command words";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^[A-Za-z]+$";
 
     public final String alias;
 

--- a/src/main/java/seedu/resireg/model/alias/Alias.java
+++ b/src/main/java/seedu/resireg/model/alias/Alias.java
@@ -10,7 +10,7 @@ import static seedu.resireg.commons.util.AppUtil.checkArgument;
 public class Alias {
 
     public static final String MESSAGE_CONSTRAINTS =
-        "Aliases should only contain alphanumeric characters and spaces, and it should not be blank";
+        "Aliases should only contain alphanumeric characters and spaces, and it should not be a command word";
 
     /*
      * The first character of the address must not be a whitespace,
@@ -35,7 +35,8 @@ public class Alias {
      * Returns true if a given string is a valid name.
      */
     public static boolean isValidAlias(String test) {
-        return test.matches(VALIDATION_REGEX);
+
+        return test.matches(VALIDATION_REGEX) && !CommandWord.isValidCommandWord(test);
     }
 
 

--- a/src/main/java/seedu/resireg/model/alias/Alias.java
+++ b/src/main/java/seedu/resireg/model/alias/Alias.java
@@ -1,0 +1,59 @@
+package seedu.resireg.model.alias;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.resireg.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Student's name in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidAlias(String)}
+ */
+public class Alias {
+
+    public static final String MESSAGE_CONSTRAINTS =
+        "Aliases should only contain alphanumeric characters and spaces, and it should not be blank";
+
+    /*
+     * The first character of the address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
+    public final String alias;
+
+    /**
+     * Constructs a {@code Alias}.
+     *
+     * @param alias A valid alias.
+     */
+    public Alias(String alias) {
+        requireNonNull(alias);
+        checkArgument(isValidAlias(alias), MESSAGE_CONSTRAINTS);
+        this.alias = alias;
+    }
+
+    /**
+     * Returns true if a given string is a valid name.
+     */
+    public static boolean isValidAlias(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+
+    @Override
+    public String toString() {
+        return alias;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof Alias // instanceof handles nulls
+            && alias.equals(((Alias) other).alias)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return alias.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/resireg/model/alias/CommandWord.java
+++ b/src/main/java/seedu/resireg/model/alias/CommandWord.java
@@ -16,6 +16,7 @@ public class CommandWord {
 
     public static final String MESSAGE_CONSTRAINTS =
         "Invalid command word. Type \"help\" to see a list of command words.";
+    public static final String VALIDATION_REGEX = "^[A-Za-z]+$";
 
     public final String commandWord;
 
@@ -35,7 +36,8 @@ public class CommandWord {
      */
     public static boolean isValidCommandWord(String test) {
         List<CommandWordEnum> commandWords = Arrays.asList(CommandWordEnum.values());
-        return commandWords.stream().anyMatch(commandWord -> commandWord.toString().equals(test));
+        return test.matches(VALIDATION_REGEX)
+            && commandWords.stream().anyMatch(commandWord -> commandWord.toString().equals(test));
     }
 
 

--- a/src/main/java/seedu/resireg/model/alias/CommandWord.java
+++ b/src/main/java/seedu/resireg/model/alias/CommandWord.java
@@ -15,7 +15,7 @@ import seedu.resireg.logic.commands.CommandWordEnum;
 public class CommandWord {
 
     public static final String MESSAGE_CONSTRAINTS =
-        "Command words should should be as defined in the User Guide. Type help to know more.";
+        "Invalid command word. Type \"help\" to see a list of command words.";
 
     public final String commandWord;
 
@@ -47,7 +47,7 @@ public class CommandWord {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-            || (other instanceof Alias // instanceof handles nulls
+            || (other instanceof CommandWord // instanceof handles nulls
             && commandWord.equals(((CommandWord) other).commandWord)); // state check
     }
 

--- a/src/main/java/seedu/resireg/model/alias/CommandWord.java
+++ b/src/main/java/seedu/resireg/model/alias/CommandWord.java
@@ -1,0 +1,59 @@
+package seedu.resireg.model.alias;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.resireg.commons.util.AppUtil.checkArgument;
+
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.resireg.logic.commands.CommandWordEnum;
+
+/**
+ * Represents a Student's name in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidCommandWord(String)}
+ */
+public class CommandWord {
+
+    public static final String MESSAGE_CONSTRAINTS =
+        "Command words should should be as defined in the User Guide. Type help to know more.";
+
+    public final String commandWord;
+
+    /**
+     * Constructs a {@code Alias}.
+     *
+     * @param commandWord A valid command word.
+     */
+    public CommandWord(String commandWord) {
+        requireNonNull(commandWord);
+        checkArgument(isValidCommandWord(commandWord), MESSAGE_CONSTRAINTS);
+        this.commandWord = commandWord;
+    }
+
+    /**
+     * Returns true if a given string is a valid name.
+     */
+    public static boolean isValidCommandWord(String test) {
+        List<CommandWordEnum> commandWords = Arrays.asList(CommandWordEnum.values());
+        return commandWords.stream().anyMatch(commandWord -> commandWord.toString().equals(test));
+    }
+
+
+    @Override
+    public String toString() {
+        return commandWord;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof Alias // instanceof handles nulls
+            && commandWord.equals(((CommandWord) other).commandWord)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return commandWord.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/resireg/model/alias/CommandWordAlias.java
+++ b/src/main/java/seedu/resireg/model/alias/CommandWordAlias.java
@@ -36,8 +36,9 @@ public class CommandWordAlias {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
             || (other instanceof CommandWordAlias // instanceof handles nulls
-            && commandWord.equals(((CommandWordAlias) other).commandWord)) // state check
-            && alias.equals(((CommandWordAlias) other).alias); // state check
+            && alias.equals(((CommandWordAlias) other).alias) // state check
+            && commandWord.equals(((CommandWordAlias) other).commandWord));
+
 
     }
 

--- a/src/main/java/seedu/resireg/model/alias/CommandWordAlias.java
+++ b/src/main/java/seedu/resireg/model/alias/CommandWordAlias.java
@@ -1,0 +1,56 @@
+package seedu.resireg.model.alias;
+
+import static seedu.resireg.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Objects;
+
+/**
+ * Represents a CommandAlias in ResiReg.
+ * Guarantees: immutable.
+ */
+public class CommandWordAlias {
+
+    public static final String MESSAGE_CONSTRAINTS = "This alias is invalid as the command word doesn't exist";
+
+    public final CommandWord commandWord;
+    public final Alias alias;
+
+    /**
+     * Every field must be present and not null.
+     */
+    public CommandWordAlias(CommandWord commandWord, Alias alias) {
+        requireAllNonNull(commandWord, alias);
+        this.commandWord = commandWord;
+        this.alias = alias;
+    }
+
+    public CommandWord getCommandWord() {
+        return commandWord;
+    }
+
+    public Alias getAlias() {
+        return alias;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof CommandWordAlias // instanceof handles nulls
+            && commandWord.equals(((CommandWordAlias) other).commandWord)) // state check
+            && alias.equals(((CommandWordAlias) other).alias); // state check
+
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(commandWord, alias);
+    }
+
+    /**
+     * Format state as text for viewing.
+     */
+    public String toString() {
+        return '\"' + commandWord.toString() + '\"' + " = " + alias.toString();
+    }
+
+}

--- a/src/main/java/seedu/resireg/model/alias/exceptions/DuplicateCommandWordAliasException.java
+++ b/src/main/java/seedu/resireg/model/alias/exceptions/DuplicateCommandWordAliasException.java
@@ -1,0 +1,11 @@
+package seedu.resireg.model.alias.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate command word aliases (Command word aliases are considered
+ * duplicates if they have the same alias).
+ */
+public class DuplicateCommandWordAliasException extends RuntimeException {
+    public DuplicateCommandWordAliasException() {
+        super("Operation would result in duplicate aliases");
+    }
+}

--- a/src/main/java/seedu/resireg/storage/JsonAdaptedCommandWordAlias.java
+++ b/src/main/java/seedu/resireg/storage/JsonAdaptedCommandWordAlias.java
@@ -44,7 +44,8 @@ class JsonAdaptedCommandWordAlias {
      */
     public CommandWordAlias toModelType() throws IllegalValueException {
         if (commandWord == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, CommandWord.class.getSimpleName()));
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                CommandWord.class.getSimpleName()));
         }
         if (!CommandWord.isValidCommandWord(commandWord)) {
             throw new IllegalValueException(CommandWord.MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/resireg/storage/JsonAdaptedCommandWordAlias.java
+++ b/src/main/java/seedu/resireg/storage/JsonAdaptedCommandWordAlias.java
@@ -1,7 +1,5 @@
 package seedu.resireg.storage;
 
-import static seedu.resireg.storage.JsonAdaptedStudent.MISSING_FIELD_MESSAGE_FORMAT;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -15,6 +13,8 @@ import seedu.resireg.model.tag.Tag;
  * Jackson-friendly version of {@link Tag}.
  */
 class JsonAdaptedCommandWordAlias {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Command word alias' %s field is missing!";
 
     private final String commandWord;
     private final String alias;

--- a/src/main/java/seedu/resireg/storage/JsonAdaptedCommandWordAlias.java
+++ b/src/main/java/seedu/resireg/storage/JsonAdaptedCommandWordAlias.java
@@ -1,0 +1,66 @@
+package seedu.resireg.storage;
+
+import static seedu.resireg.storage.JsonAdaptedStudent.MISSING_FIELD_MESSAGE_FORMAT;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.resireg.commons.exceptions.IllegalValueException;
+import seedu.resireg.model.alias.Alias;
+import seedu.resireg.model.alias.CommandWord;
+import seedu.resireg.model.alias.CommandWordAlias;
+import seedu.resireg.model.tag.Tag;
+
+/**
+ * Jackson-friendly version of {@link Tag}.
+ */
+class JsonAdaptedCommandWordAlias {
+
+    private final String commandWord;
+    private final String alias;
+
+    /**
+     * Constructs a {@code JsonAdaptedTag} with the given {@code tagName}.
+     */
+    @JsonCreator
+    public JsonAdaptedCommandWordAlias(@JsonProperty("commandWord") String commandWord,
+                          @JsonProperty("alias") String alias) {
+        this.commandWord = commandWord;
+        this.alias = alias;
+    }
+
+    /**
+     * Converts a given {@code Tag} into this class for Jackson use.
+     */
+    public JsonAdaptedCommandWordAlias(CommandWordAlias source) {
+        this.commandWord = source.getCommandWord().toString();
+        this.alias = source.getAlias().toString();
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted CommandWordAlias object into the model's {@code CommandWordAlias} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted command word alias.
+     */
+    public CommandWordAlias toModelType() throws IllegalValueException {
+        if (commandWord == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, CommandWord.class.getSimpleName()));
+        }
+        if (!CommandWord.isValidCommandWord(commandWord)) {
+            throw new IllegalValueException(CommandWord.MESSAGE_CONSTRAINTS);
+        }
+        final CommandWord modelCommandWord = new CommandWord(commandWord);
+
+        if (alias == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Alias.class.getSimpleName()));
+        }
+        if (!Alias.isValidAlias(alias)) {
+            throw new IllegalValueException(Alias.MESSAGE_CONSTRAINTS);
+        }
+        final Alias modelAlias = new Alias(alias);
+
+
+        return new CommandWordAlias(modelCommandWord, modelAlias);
+    }
+
+}

--- a/src/main/java/seedu/resireg/storage/JsonSerializableUserPrefs.java
+++ b/src/main/java/seedu/resireg/storage/JsonSerializableUserPrefs.java
@@ -32,8 +32,8 @@ class JsonSerializableUserPrefs {
      */
     @JsonCreator
     public JsonSerializableUserPrefs(@JsonProperty("guiSettings") GuiSettings guiSettings,
-                                     @JsonProperty("aliases") List<JsonAdaptedCommandWordAlias> aliases,
-                                     @JsonProperty("addressBookFilePath") Path addressBookFilePath){
+                                     @JsonProperty("commandWordAliases") List<JsonAdaptedCommandWordAlias> aliases,
+                                     @JsonProperty("addressBookFilePath") Path addressBookFilePath) {
         this.commandWordAliases.addAll(aliases);
         this.guiSettings = guiSettings;
         this.addressBookFilePath = addressBookFilePath;
@@ -45,7 +45,7 @@ class JsonSerializableUserPrefs {
      * @param source future changes to this will not affect the created {@code JsonSerializableAddressBook}.
      */
     public JsonSerializableUserPrefs(ReadOnlyUserPrefs source) {
-        commandWordAliases.addAll(source.getCommandAliases().stream().map(JsonAdaptedCommandWordAlias::new)
+        commandWordAliases.addAll(source.getCommandWordAliases().stream().map(JsonAdaptedCommandWordAlias::new)
             .collect(Collectors.toList()));
         this.guiSettings = source.getGuiSettings();
         this.addressBookFilePath = source.getAddressBookFilePath();
@@ -58,8 +58,8 @@ class JsonSerializableUserPrefs {
      */
     public UserPrefs toModelType() throws IllegalValueException {
         UserPrefs userPrefs = new UserPrefs();
-        for (JsonAdaptedCommandWordAlias jsonAdpatedCommandWordAlias : commandWordAliases) {
-            CommandWordAlias commandWordAlias = jsonAdpatedCommandWordAlias.toModelType();
+        for (JsonAdaptedCommandWordAlias jsonAdaptedCommandWordAlias : commandWordAliases) {
+            CommandWordAlias commandWordAlias = jsonAdaptedCommandWordAlias.toModelType();
             if (userPrefs.hasAlias(commandWordAlias)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_ALIAS);
             }

--- a/src/main/java/seedu/resireg/storage/JsonSerializableUserPrefs.java
+++ b/src/main/java/seedu/resireg/storage/JsonSerializableUserPrefs.java
@@ -1,0 +1,75 @@
+package seedu.resireg.storage;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import seedu.resireg.commons.core.GuiSettings;
+import seedu.resireg.commons.exceptions.IllegalValueException;
+import seedu.resireg.model.ReadOnlyUserPrefs;
+import seedu.resireg.model.UserPrefs;
+import seedu.resireg.model.alias.CommandWordAlias;
+
+/**
+ * An Immutable AddressBook that is serializable to JSON format.
+ */
+@JsonRootName(value = "preferences")
+class JsonSerializableUserPrefs {
+
+    public static final String MESSAGE_DUPLICATE_ALIAS = "Alias list contains duplicate alias(es).";
+
+    private final List<JsonAdaptedCommandWordAlias> commandWordAliases = new ArrayList<>();
+    private final GuiSettings guiSettings;
+    private final Path addressBookFilePath;
+
+    /**
+     * Constructs a {@code JsonSerializableAddressBook} with the given students.
+     */
+    @JsonCreator
+    public JsonSerializableUserPrefs(@JsonProperty("guiSettings") GuiSettings guiSettings,
+                                     @JsonProperty("aliases") List<JsonAdaptedCommandWordAlias> aliases,
+                                     @JsonProperty("addressBookFilePath") Path addressBookFilePath){
+        this.commandWordAliases.addAll(aliases);
+        this.guiSettings = guiSettings;
+        this.addressBookFilePath = addressBookFilePath;
+    }
+
+    /**
+     * Converts a given {@code ReadOnlyAddressBook} into this class for Jackson use.
+     *
+     * @param source future changes to this will not affect the created {@code JsonSerializableAddressBook}.
+     */
+    public JsonSerializableUserPrefs(ReadOnlyUserPrefs source) {
+        commandWordAliases.addAll(source.getCommandAliases().stream().map(JsonAdaptedCommandWordAlias::new)
+            .collect(Collectors.toList()));
+        this.guiSettings = source.getGuiSettings();
+        this.addressBookFilePath = source.getAddressBookFilePath();
+    }
+
+    /**
+     * Converts this address book into the model's {@code AddressBook} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated.
+     */
+    public UserPrefs toModelType() throws IllegalValueException {
+        UserPrefs userPrefs = new UserPrefs();
+        for (JsonAdaptedCommandWordAlias jsonAdpatedCommandWordAlias : commandWordAliases) {
+            CommandWordAlias commandWordAlias = jsonAdpatedCommandWordAlias.toModelType();
+            if (userPrefs.hasAlias(commandWordAlias)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_ALIAS);
+            }
+            userPrefs.addAlias(commandWordAlias);
+        }
+
+        userPrefs.setGuiSettings(guiSettings);
+        userPrefs.setAddressBookFilePath(addressBookFilePath);
+
+        return userPrefs;
+    }
+
+}

--- a/src/main/java/seedu/resireg/storage/JsonUserPrefsStorage.java
+++ b/src/main/java/seedu/resireg/storage/JsonUserPrefsStorage.java
@@ -64,6 +64,13 @@ public class JsonUserPrefsStorage implements UserPrefsStorage {
         saveUserPrefs(userPrefs, filePath);
     }
 
+    /**
+     * Saves the UserPrefs object as a Json file.
+     *
+     * @param userPrefs the existing data to be saved
+     * @param filePath the file path denoting the storage
+     * @throws IOException
+     */
     public void saveUserPrefs(ReadOnlyUserPrefs userPrefs, Path filePath) throws IOException {
         requireNonNull(userPrefs);
         requireNonNull(filePath);

--- a/src/main/java/seedu/resireg/storage/JsonUserPrefsStorage.java
+++ b/src/main/java/seedu/resireg/storage/JsonUserPrefsStorage.java
@@ -1,10 +1,16 @@
 package seedu.resireg.storage;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.logging.Logger;
 
+import seedu.resireg.commons.core.LogsCenter;
 import seedu.resireg.commons.exceptions.DataConversionException;
+import seedu.resireg.commons.exceptions.IllegalValueException;
+import seedu.resireg.commons.util.FileUtil;
 import seedu.resireg.commons.util.JsonUtil;
 import seedu.resireg.model.ReadOnlyUserPrefs;
 import seedu.resireg.model.UserPrefs;
@@ -13,6 +19,8 @@ import seedu.resireg.model.UserPrefs;
  * A class to access UserPrefs stored in the hard disk as a json file
  */
 public class JsonUserPrefsStorage implements UserPrefsStorage {
+
+    private static final Logger logger = LogsCenter.getLogger(JsonAddressBookStorage.class);
 
     private Path filePath;
 
@@ -36,12 +44,32 @@ public class JsonUserPrefsStorage implements UserPrefsStorage {
      * @throws DataConversionException if the file format is not as expected.
      */
     public Optional<UserPrefs> readUserPrefs(Path prefsFilePath) throws DataConversionException {
-        return JsonUtil.readJsonFile(prefsFilePath, UserPrefs.class);
+
+        Optional<JsonSerializableUserPrefs> jsonUserPrefs = JsonUtil.readJsonFile(
+            filePath, JsonSerializableUserPrefs.class);
+        if (!jsonUserPrefs.isPresent()) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(jsonUserPrefs.get().toModelType());
+        } catch (IllegalValueException ive) {
+            logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
+            throw new DataConversionException(ive);
+        }
     }
 
     @Override
     public void saveUserPrefs(ReadOnlyUserPrefs userPrefs) throws IOException {
-        JsonUtil.saveJsonFile(userPrefs, filePath);
+        saveUserPrefs(userPrefs, filePath);
+    }
+
+    public void saveUserPrefs(ReadOnlyUserPrefs userPrefs, Path filePath) throws IOException {
+        requireNonNull(userPrefs);
+        requireNonNull(filePath);
+
+        FileUtil.createIfMissing(filePath);
+        JsonUtil.saveJsonFile(new JsonSerializableUserPrefs(userPrefs), filePath);
     }
 
 }

--- a/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
@@ -9,5 +9,6 @@
       "z" : 99
     }
   },
-  "addressBookFilePath" : "addressbook.json"
+  "addressBookFilePath" : "addressbook.json",
+  "commandWordAliases" : []
 }

--- a/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
@@ -7,5 +7,6 @@
       "y" : 100
     }
   },
-  "addressBookFilePath" : "addressbook.json"
+  "addressBookFilePath" : "addressbook.json",
+  "commandWordAliases" : []
 }

--- a/src/test/java/seedu/resireg/logic/commands/AddAliasCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/AddAliasCommandTest.java
@@ -17,66 +17,66 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.ObservableList;
 import seedu.resireg.commons.core.GuiSettings;
 import seedu.resireg.logic.commands.exceptions.CommandException;
-import seedu.resireg.model.AddressBook;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ReadOnlyAddressBook;
 import seedu.resireg.model.ReadOnlyUserPrefs;
+import seedu.resireg.model.UserPrefs;
 import seedu.resireg.model.alias.CommandWordAlias;
 import seedu.resireg.model.allocation.Allocation;
 import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.Student;
-import seedu.resireg.testutil.StudentBuilder;
+import seedu.resireg.testutil.CommandWordAliasBuilder;
 
-public class AddCommandTest {
+public class AddAliasCommandTest {
 
     @Test
-    public void constructor_nullStudent_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new AddCommand(null));
+    public void constructor_nullAlias_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddAliasCommand(null));
     }
 
     @Test
-    public void execute_studentAcceptedByModel_addSuccessful() throws Exception {
-        ModelStubAcceptingStudentAdded modelStub = new ModelStubAcceptingStudentAdded();
-        Student validStudent = new StudentBuilder().build();
+    public void execute_aliasAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingAliasAdded modelStub = new ModelStubAcceptingAliasAdded();
+        CommandWordAlias validAlias = new CommandWordAliasBuilder().build();
 
-        CommandResult commandResult = new AddCommand(validStudent).execute(modelStub);
+        CommandResult commandResult = new AddAliasCommand(validAlias).execute(modelStub);
 
-        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, validStudent.getName().fullName,
-            validStudent.getStudentId().value), commandResult.getFeedbackToUser());
-        assertEquals(Arrays.asList(validStudent), modelStub.studentsAdded);
+        assertEquals(String.format(AddAliasCommand.MESSAGE_SUCCESS, validAlias), commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validAlias), modelStub.aliasesAdded);
     }
 
     @Test
-    public void execute_duplicateStudent_throwsCommandException() {
-        Student validStudent = new StudentBuilder().build();
-        AddCommand addCommand = new AddCommand(validStudent);
-        ModelStub modelStub = new ModelStubWithStudent(validStudent);
+    public void execute_duplicateAlias_throwsCommandException() {
+        CommandWordAlias validAlias = new CommandWordAliasBuilder().build();
+        AddAliasCommand addAliasCommand = new AddAliasCommand(validAlias);
+        ModelStub modelStub = new ModelStubWithAlias(validAlias);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
+        assertThrows(CommandException.class,
+            AddAliasCommand.MESSAGE_DUPLICATE_ALIAS, () -> addAliasCommand.execute(modelStub));
     }
 
     @Test
     public void equals() {
-        Student alice = new StudentBuilder().withName("Alice").build();
-        Student bob = new StudentBuilder().withName("Bob").build();
-        AddCommand addAliceCommand = new AddCommand(alice);
-        AddCommand addBobCommand = new AddCommand(bob);
+        CommandWordAlias roomsR = new CommandWordAliasBuilder().withAlias("r").build();
+        CommandWordAlias roomsRo = new CommandWordAliasBuilder().withAlias("ro").build();
+        AddAliasCommand addRoomsRCommand = new AddAliasCommand(roomsR);
+        AddAliasCommand addRoomsRoCommand = new AddAliasCommand(roomsRo);
 
         // same object -> returns true
-        assertTrue(addAliceCommand.equals(addAliceCommand));
+        assertTrue(addRoomsRCommand.equals(addRoomsRCommand));
 
         // same values -> returns true
-        AddCommand addAliceCommandCopy = new AddCommand(alice);
-        assertTrue(addAliceCommand.equals(addAliceCommandCopy));
+        AddAliasCommand addRoomsRCommandCopy = new AddAliasCommand(roomsR);
+        assertTrue(addRoomsRCommand.equals(addRoomsRCommandCopy));
 
         // different types -> returns false
-        assertFalse(addAliceCommand.equals(1));
+        assertFalse(addRoomsRCommandCopy.equals(1));
 
         // null -> returns false
-        assertFalse(addAliceCommand.equals(null));
+        assertFalse(addRoomsRCommandCopy.equals(null));
 
-        // different student -> returns false
-        assertFalse(addAliceCommand.equals(addBobCommand));
+        // different command -> returns false
+        assertFalse(addRoomsRCommand.equals(addRoomsRoCommand));
     }
 
     /**
@@ -277,47 +277,42 @@ public class AddCommandTest {
     /**
      * A Model stub that contains a single student.
      */
-    private class ModelStubWithStudent extends ModelStub {
-        private final Student student;
+    private class ModelStubWithAlias extends ModelStub {
+        private final CommandWordAlias commandWordAlias;
 
-        ModelStubWithStudent(Student student) {
-            requireNonNull(student);
-            this.student = student;
+        ModelStubWithAlias(CommandWordAlias commandWordAlias) {
+            requireNonNull(commandWordAlias);
+            this.commandWordAlias = commandWordAlias;
         }
 
         @Override
-        public boolean hasStudent(Student student) {
-            requireNonNull(student);
-            return this.student.isSameStudent(student);
+        public boolean hasCommandWordAlias(CommandWordAlias commandWordAlias) {
+            requireNonNull(commandWordAlias);
+            return this.commandWordAlias.getAlias().equals(commandWordAlias.getAlias());
         }
     }
 
     /**
      * A Model stub that always accept the student being added.
      */
-    private class ModelStubAcceptingStudentAdded extends ModelStub {
-        final ArrayList<Student> studentsAdded = new ArrayList<>();
+    private class ModelStubAcceptingAliasAdded extends ModelStub {
+        final ArrayList<CommandWordAlias> aliasesAdded = new ArrayList<>();
 
         @Override
-        public boolean hasStudent(Student student) {
-            requireNonNull(student);
-            return studentsAdded.stream().anyMatch(student::isSameStudent);
+        public boolean hasCommandWordAlias(CommandWordAlias commandWordAlias) {
+            requireNonNull(commandWordAlias);
+            return aliasesAdded.stream().anyMatch(commandWordAlias::equals);
         }
 
         @Override
-        public void addStudent(Student student) {
-            requireNonNull(student);
-            studentsAdded.add(student);
+        public void addCommandWordAlias(CommandWordAlias commandWordAlias) {
+            requireNonNull(commandWordAlias);
+            aliasesAdded.add(commandWordAlias);
         }
 
         @Override
-        public void saveStateResiReg() {
-            // called by {@code AddCommand#execute()}
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            return new AddressBook();
+        public ReadOnlyUserPrefs getUserPrefs() {
+            return new UserPrefs();
         }
     }
 

--- a/src/test/java/seedu/resireg/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/AddCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.resireg.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,7 @@ import seedu.resireg.model.AddressBook;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ReadOnlyAddressBook;
 import seedu.resireg.model.ReadOnlyUserPrefs;
+import seedu.resireg.model.alias.CommandWordAlias;
 import seedu.resireg.model.allocation.Allocation;
 import seedu.resireg.model.room.Room;
 import seedu.resireg.model.student.Student;
@@ -98,6 +100,26 @@ public class AddCommandTest {
 
         @Override
         public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Map<String, String> getAliasWordMap() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasCommandWordAlias(CommandWordAlias target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteCommandWordAlias(CommandWordAlias target) {
+            throw new AssertionError("This method should not be called.");
+        };
+
+        @Override
+        public void addCommandWordAlias(CommandWordAlias source) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/resireg/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/resireg/logic/commands/CommandTestUtil.java
@@ -2,6 +2,8 @@ package seedu.resireg.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_ALIAS;
+import static seedu.resireg.logic.parser.CliSyntax.PREFIX_COMMAND;
 import static seedu.resireg.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.resireg.logic.parser.CliSyntax.PREFIX_FACULTY;
 import static seedu.resireg.logic.parser.CliSyntax.PREFIX_NAME;
@@ -29,7 +31,7 @@ import seedu.resireg.testutil.EditStudentDescriptorBuilder;
  * Contains helper methods for testing commands.
  */
 public class CommandTestUtil {
-
+    // Valid students
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";
@@ -43,6 +45,7 @@ public class CommandTestUtil {
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
+    // Valid rooms
     public static final String VALID_FLOOR_A = "21";
     public static final String VALID_FLOOR_B = "7";
     public static final String VALID_ROOM_NUMBER_A = "120";
@@ -51,6 +54,12 @@ public class CommandTestUtil {
     public static final String VALID_ROOM_TYPE_B = "NA";
     public static final String VALID_TAG_RENOVATED = "renovated";
     public static final String VALID_TAG_DAMAGED = "damaged";
+
+    // Valid command word aliases
+    public static final String VALID_COMMAND_ROOMS_RO = "rooms";
+    public static final String VALID_COMMAND_STUDENTS_ST = "students";
+    public static final String VALID_ALIAS_ROOMS_RO = "ro";
+    public static final String VALID_ALIAS_STUDENTS_ST = "st";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -65,12 +74,21 @@ public class CommandTestUtil {
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
+    public static final String COMMAND_DESC_ROOMS_RO = " " + PREFIX_COMMAND + VALID_COMMAND_ROOMS_RO;
+    public static final String COMMAND_DESC_STUDENTS_STU = " " + PREFIX_COMMAND + VALID_COMMAND_STUDENTS_ST;
+    public static final String ALIAS_DESC_ROOMS_RO = " " + PREFIX_ALIAS + VALID_ALIAS_ROOMS_RO;
+    public static final String ALIAS_DESC_STUDENTS_STU = " " + PREFIX_ALIAS + VALID_ALIAS_STUDENTS_ST;
+
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_FACULTY_DESC = " " + PREFIX_FACULTY; // empty string not allowed for faculties
     public static final String INVALID_STUDENT_ID_DESC = " " + PREFIX_STUDENT_ID; // empty string not allowed for ids
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+
+    public static final String INVALID_COMMAND_DESC = " " + PREFIX_COMMAND + "71ndn"; // command word doesn't exist
+    // alias cant be a command word
+    public static final String INVALID_ALIAS_DESC = " " + PREFIX_ALIAS + ListRoomCommand.COMMAND_WORD;
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/resireg/logic/commands/DeleteAliasCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/DeleteAliasCommandTest.java
@@ -1,0 +1,71 @@
+package seedu.resireg.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.resireg.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.resireg.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.resireg.testutil.TypicalCommandWordAliases.FIND_FI;
+import static seedu.resireg.testutil.TypicalCommandWordAliases.ROOMS_R;
+import static seedu.resireg.testutil.TypicalCommandWordAliases.ROOMS_RO;
+import static seedu.resireg.testutil.TypicalCommandWordAliases.STUDENTS_STU;
+import static seedu.resireg.testutil.TypicalCommandWordAliases.getTypicalUserPrefs;
+import static seedu.resireg.testutil.TypicalStudents.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.resireg.model.Model;
+import seedu.resireg.model.ModelManager;
+import seedu.resireg.model.alias.CommandWordAlias;
+
+/**
+ * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
+ * {@code DeleteCommand}.
+ */
+public class DeleteAliasCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalUserPrefs());
+
+    @Test
+    public void execute_validAlias_success() {
+        CommandWordAlias aliasToDelete = FIND_FI;
+        DeleteAliasCommand deleteCommand = new DeleteAliasCommand(FIND_FI);
+
+        String expectedMessage = String.format(DeleteAliasCommand.MESSAGE_SUCCESS, aliasToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), model.getUserPrefs());
+        expectedModel.deleteCommandWordAlias(aliasToDelete);
+
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidAlias_throwsCommandException() {
+        CommandWordAlias outOfBoundAlias = ROOMS_RO;
+        DeleteAliasCommand deleteCommand = new DeleteAliasCommand(ROOMS_RO);
+
+        assertCommandFailure(deleteCommand, model, DeleteAliasCommand.MESSAGE_INVALID_ALIAS);
+    }
+
+    @Test
+    public void equals() {
+        DeleteAliasCommand deleteFirstCommand = new DeleteAliasCommand(ROOMS_R);
+        DeleteAliasCommand deleteSecondCommand = new DeleteAliasCommand(STUDENTS_STU);
+
+        // same object -> returns true
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+
+        // same values -> returns true
+        DeleteAliasCommand deleteFirstCommandCopy = new DeleteAliasCommand(ROOMS_R);
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteFirstCommand.equals(null));
+
+        // different command word alias -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+}

--- a/src/test/java/seedu/resireg/logic/commands/ListAliasCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/ListAliasCommandTest.java
@@ -1,0 +1,47 @@
+package seedu.resireg.logic.commands;
+
+import static seedu.resireg.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.resireg.testutil.TypicalCommandWordAliases.getTypicalUserPrefs;
+import static seedu.resireg.testutil.TypicalStudents.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.resireg.model.AddressBook;
+import seedu.resireg.model.Model;
+import seedu.resireg.model.ModelManager;
+import seedu.resireg.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
+ */
+public class ListAliasCommandTest {
+
+    private Model fullModel;
+    private Model expectedFullModel;
+
+    private Model emptyModel;
+    private Model expectedEmptyModel;
+
+    @BeforeEach
+    public void setUp() {
+        fullModel = new ModelManager(getTypicalAddressBook(), getTypicalUserPrefs());
+        expectedFullModel = new ModelManager(fullModel.getAddressBook(), fullModel.getUserPrefs());
+
+        emptyModel = new ModelManager(new AddressBook(), new UserPrefs());
+        expectedEmptyModel = new ModelManager(emptyModel.getAddressBook(), emptyModel.getUserPrefs());
+    }
+
+    @Test
+    public void execute_listExists_showsSameList() {
+        assertCommandSuccess(new ListAliasCommand(), fullModel,
+            String.format(ListAliasCommand.MESSAGE_SUCCESS, fullModel.getCommandWordAliasesAsString()),
+            expectedFullModel);
+    }
+
+    @Test
+    public void execute_listIsEmpty_showsEmptyMessage() {
+        assertCommandSuccess(new ListAliasCommand(), emptyModel,
+            ListAliasCommand.MESSAGE_EMPTY_ALIAS, expectedEmptyModel);
+    }
+}

--- a/src/test/java/seedu/resireg/logic/parser/AddAliasCommandParserTest.java
+++ b/src/test/java/seedu/resireg/logic/parser/AddAliasCommandParserTest.java
@@ -1,0 +1,75 @@
+package seedu.resireg.logic.parser;
+
+import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.resireg.logic.commands.CommandTestUtil.ALIAS_DESC_ROOMS_RO;
+import static seedu.resireg.logic.commands.CommandTestUtil.COMMAND_DESC_ROOMS_RO;
+import static seedu.resireg.logic.commands.CommandTestUtil.COMMAND_DESC_STUDENTS_STU;
+import static seedu.resireg.logic.commands.CommandTestUtil.INVALID_ALIAS_DESC;
+import static seedu.resireg.logic.commands.CommandTestUtil.INVALID_COMMAND_DESC;
+import static seedu.resireg.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.resireg.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ALIAS_ROOMS_RO;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_COMMAND_ROOMS_RO;
+import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.resireg.testutil.TypicalCommandWordAliases.ROOMS_RO;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.resireg.logic.commands.AddAliasCommand;
+import seedu.resireg.model.alias.Alias;
+import seedu.resireg.model.alias.CommandWord;
+import seedu.resireg.model.alias.CommandWordAlias;
+import seedu.resireg.testutil.CommandWordAliasBuilder;
+
+public class AddAliasCommandParserTest {
+    private AddAliasCommandParser parser = new AddAliasCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        CommandWordAlias expectedAlias = new CommandWordAliasBuilder(ROOMS_RO).build();
+
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + COMMAND_DESC_ROOMS_RO
+            + ALIAS_DESC_ROOMS_RO, new AddAliasCommand(expectedAlias));
+
+        // multiple command words - last name accepted
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + COMMAND_DESC_STUDENTS_STU + COMMAND_DESC_ROOMS_RO
+            + ALIAS_DESC_ROOMS_RO, new AddAliasCommand(expectedAlias));
+
+    }
+
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddAliasCommand.HELP.getFullMessage());
+
+        // missing command word prefix
+        assertParseFailure(parser, VALID_COMMAND_ROOMS_RO + ALIAS_DESC_ROOMS_RO,
+            expectedMessage);
+
+        // missing alias prefix
+        assertParseFailure(parser, COMMAND_DESC_ROOMS_RO + VALID_ALIAS_ROOMS_RO,
+            expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, VALID_COMMAND_ROOMS_RO + VALID_ALIAS_ROOMS_RO, expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid command word
+        assertParseFailure(parser, INVALID_COMMAND_DESC + ALIAS_DESC_ROOMS_RO, CommandWord.MESSAGE_CONSTRAINTS);
+
+        // invalid alias
+        assertParseFailure(parser, COMMAND_DESC_ROOMS_RO + INVALID_ALIAS_DESC, Alias.MESSAGE_CONSTRAINTS);
+
+
+        // two invalid values, only first invalid value reported
+        assertParseFailure(parser, INVALID_COMMAND_DESC + INVALID_ALIAS_DESC, CommandWord.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + COMMAND_DESC_ROOMS_RO + ALIAS_DESC_ROOMS_RO,
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddAliasCommand.HELP.getFullMessage()));
+    }
+}

--- a/src/test/java/seedu/resireg/model/AddressBookTest.java
+++ b/src/test/java/seedu/resireg/model/AddressBookTest.java
@@ -4,11 +4,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.resireg.logic.commands.CommandTestUtil.VALID_FACULTY_BOB;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ROOM_TYPE_B;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_TAG_DAMAGED;
 import static seedu.resireg.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_TAG_RENOVATED;
 import static seedu.resireg.testutil.Assert.assertThrows;
+import static seedu.resireg.testutil.TypicalRooms.ROOM_ONE;
 import static seedu.resireg.testutil.TypicalStudents.ALICE;
 import static seedu.resireg.testutil.TypicalStudents.getTypicalAddressBook;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -20,8 +25,10 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.resireg.model.allocation.Allocation;
 import seedu.resireg.model.room.Room;
+import seedu.resireg.model.room.exceptions.DuplicateRoomException;
 import seedu.resireg.model.student.Student;
 import seedu.resireg.model.student.exceptions.DuplicateStudentException;
+import seedu.resireg.testutil.RoomBuilder;
 import seedu.resireg.testutil.StudentBuilder;
 
 public class AddressBookTest {
@@ -51,7 +58,7 @@ public class AddressBookTest {
         Student editedAlice = new StudentBuilder(ALICE).withFaculty(VALID_FACULTY_BOB).withTags(VALID_TAG_HUSBAND)
                 .build();
         List<Student> newStudents = Arrays.asList(ALICE, editedAlice);
-        AddressBookStub newData = new AddressBookStub(newStudents);
+        AddressBookStub newData = new AddressBookStub(newStudents, new ArrayList<>());
 
         assertThrows(DuplicateStudentException.class, () -> addressBook.resetData(newData));
     }
@@ -85,6 +92,47 @@ public class AddressBookTest {
         assertThrows(UnsupportedOperationException.class, () -> addressBook.getStudentList().remove(0));
     }
 
+
+    // Rooms
+    @Test
+    public void resetData_withDuplicateRooms_throwsDuplicateRoomException() {
+        // Two rooms with the same identity fields
+        Room editedOne = new RoomBuilder(ROOM_ONE).withTags(VALID_TAG_RENOVATED).build();
+        List<Room> newRooms = Arrays.asList(ROOM_ONE, editedOne);
+        AddressBookStub newData = new AddressBookStub(new ArrayList<>(), newRooms);
+
+        assertThrows(DuplicateRoomException.class, () -> addressBook.resetData(newData));
+    }
+
+    @Test
+    public void hasRoom_nullRoom_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> addressBook.hasRoom(null));
+    }
+
+    @Test
+    public void hasRoom_roomNotInResiReg_returnsFalse() {
+        assertFalse(addressBook.hasRoom(ROOM_ONE));
+    }
+
+    @Test
+    public void hasRoom_roomInResiReg_returnsTrue() {
+        addressBook.addRoom(ROOM_ONE);
+        assertTrue(addressBook.hasRoom(ROOM_ONE));
+    }
+
+    @Test
+    public void hasRoom_roomWithSameIdentityFieldsInResiReg_returnsTrue() {
+        addressBook.addRoom(ROOM_ONE);
+        Room editedRoom = new RoomBuilder(ROOM_ONE).withRoomType(VALID_ROOM_TYPE_B).withTags(VALID_TAG_DAMAGED)
+            .build();
+        assertTrue(addressBook.hasRoom(editedRoom));
+    }
+
+    @Test
+    public void getRoomList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> addressBook.getRoomList().remove(0));
+    }
+
     /**
      * A stub ReadOnlyAddressBook whose students list can violate interface constraints.
      */
@@ -93,8 +141,9 @@ public class AddressBookTest {
         private final ObservableList<Room> rooms = FXCollections.observableArrayList();
         private final ObservableList<Allocation> allocations = FXCollections.observableArrayList();
 
-        AddressBookStub(Collection<Student> students) {
-            this.students.setAll(students); // todo: set rooms
+        AddressBookStub(Collection<Student> students, Collection<Room> rooms) {
+            this.students.setAll(students);
+            this.rooms.setAll(rooms);
         }
 
         @Override

--- a/src/test/java/seedu/resireg/model/ModelManagerTest.java
+++ b/src/test/java/seedu/resireg/model/ModelManagerTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.resireg.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.resireg.testutil.Assert.assertThrows;
+import static seedu.resireg.testutil.TypicalCommandWordAliases.ROOMS_R;
+import static seedu.resireg.testutil.TypicalCommandWordAliases.STUDENTS_ST;
+import static seedu.resireg.testutil.TypicalRooms.ROOM_ONE;
 import static seedu.resireg.testutil.TypicalStudents.ALICE;
 import static seedu.resireg.testutil.TypicalStudents.BENSON;
 
@@ -17,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import seedu.resireg.commons.core.GuiSettings;
 import seedu.resireg.model.student.NameContainsKeywordsPredicate;
 import seedu.resireg.testutil.AddressBookBuilder;
+import seedu.resireg.testutil.UserPrefsBuilder;
 
 public class ModelManagerTest {
 
@@ -93,11 +97,60 @@ public class ModelManagerTest {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredStudentList().remove(0));
     }
 
+    // Rooms
+    @Test
+    public void getFilteredRoomList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredRoomList().remove(0));
+    }
+
+    @Test
+    public void hasRoom_nullRoom_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasRoom(null));
+    }
+
+    @Test
+    public void hasRoom_roomNotInResiReg_returnsFalse() {
+        assertFalse(modelManager.hasRoom(ROOM_ONE));
+    }
+
+    @Test
+    public void hasRoom_roomInResiReg_returnsTrue() {
+        modelManager.addRoom(ROOM_ONE);
+        assertTrue(modelManager.hasRoom(ROOM_ONE));
+    }
+
+    // Allocations (to be added)
+
+    // Command word aliases
+    @Test
+    public void getAliasList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getCommandWordAliases().remove(0));
+    }
+
+    @Test
+    public void hasCommandWordAlias_nullAlias_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasCommandWordAlias(null));
+    }
+
+    @Test
+    public void hasCommandWordAlias_aliasNotInUserPrefs_returnsFalse() {
+        assertFalse(modelManager.hasCommandWordAlias(ROOMS_R));
+    }
+
+    @Test
+    public void hasCommandWordAlias_aliasInUserPrefs_returnsTrue() {
+        modelManager.addCommandWordAlias(ROOMS_R);
+        assertTrue(modelManager.hasCommandWordAlias(ROOMS_R));
+    }
+
     @Test
     public void equals() {
         AddressBook addressBook = new AddressBookBuilder().withStudent(ALICE).withStudent(BENSON).build();
         AddressBook differentAddressBook = new AddressBook();
-        UserPrefs userPrefs = new UserPrefs();
+        UserPrefs userPrefs = new UserPrefsBuilder().withCommandWordAlias(ROOMS_R)
+            .withCommandWordAlias(STUDENTS_ST).build();
+        UserPrefs differentUserPrefs = new UserPrefs();
+
 
         // same values -> returns true
         modelManager = new ModelManager(addressBook, userPrefs);
@@ -116,16 +169,23 @@ public class ModelManagerTest {
         // different addressBook -> returns false
         assertFalse(modelManager.equals(new ModelManager(differentAddressBook, userPrefs)));
 
+        // different addressBook -> returns false
+        assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs)));
+
         // different filteredList -> returns false
         String[] keywords = ALICE.getName().fullName.split("\\s+");
         modelManager.updateFilteredStudentList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
         assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
 
+        // different alias list -> returns false
+        modelManager.deleteCommandWordAlias(STUDENTS_ST);
+        assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
+
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredStudentList(PREDICATE_SHOW_ALL_PERSONS);
+        modelManager.addCommandWordAlias(STUDENTS_ST);
 
         // different userPrefs -> returns false
-        UserPrefs differentUserPrefs = new UserPrefs();
         differentUserPrefs.setAddressBookFilePath(Paths.get("differentFilePath"));
         assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs)));
     }

--- a/src/test/java/seedu/resireg/model/UserPrefsTest.java
+++ b/src/test/java/seedu/resireg/model/UserPrefsTest.java
@@ -1,10 +1,25 @@
 package seedu.resireg.model;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.resireg.testutil.Assert.assertThrows;
+import static seedu.resireg.testutil.TypicalCommandWordAliases.ROOMS_R;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.resireg.commons.core.GuiSettings;
+import seedu.resireg.model.alias.CommandWordAlias;
+import seedu.resireg.model.alias.exceptions.DuplicateCommandWordAliasException;
+import seedu.resireg.testutil.CommandWordAliasBuilder;
+
 public class UserPrefsTest {
+
+    private final UserPrefs userPrefs = new UserPrefs();
 
     @Test
     public void setGuiSettings_nullGuiSettings_throwsNullPointerException() {
@@ -16,6 +31,59 @@ public class UserPrefsTest {
     public void setAddressBookFilePath_nullPath_throwsNullPointerException() {
         UserPrefs userPrefs = new UserPrefs();
         assertThrows(NullPointerException.class, () -> userPrefs.setAddressBookFilePath(null));
+    }
+
+    @Test
+    public void resetData_withDuplicateAliases_throwsDuplicateCommandWordAliasException() {
+        CommandWordAlias editedAlias = new CommandWordAliasBuilder(ROOMS_R).build();
+        List<CommandWordAlias> newAliases = Arrays.asList(ROOMS_R, editedAlias);
+        UserPrefsStub newData = new UserPrefsStub(newAliases);
+
+        assertThrows(DuplicateCommandWordAliasException.class, () -> userPrefs.resetData(newData));
+    }
+
+    @Test
+    public void hasAlias_nullAlias_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> userPrefs.hasAlias(null));
+    }
+
+    @Test
+    public void hasAlias_aliasNotInUserPrefs_returnsFalse() {
+        assertFalse(userPrefs.hasAlias(ROOMS_R));
+    }
+
+    @Test
+    public void hasAlias_aliasInUserPrefs_returnsTrue() {
+        userPrefs.addAlias(ROOMS_R);
+        assertTrue(userPrefs.hasAlias(ROOMS_R));
+    }
+
+    /**
+     * A stub ReadOnlyAddressBook whose students list can violate interface constraints.
+     */
+    private static class UserPrefsStub implements ReadOnlyUserPrefs {
+        private GuiSettings guiSettings = new GuiSettings();
+        private List<CommandWordAlias> commandWordAliases;
+        private Path addressBookFilePath = Paths.get("data" , "addressbook.json");
+
+        UserPrefsStub(List<CommandWordAlias> commandWordAliases) {
+            this.commandWordAliases = commandWordAliases;
+        }
+
+        @Override
+        public GuiSettings getGuiSettings() {
+            return guiSettings;
+        }
+
+        @Override
+        public List<CommandWordAlias> getCommandWordAliases() {
+            return commandWordAliases;
+        }
+
+        @Override
+        public Path getAddressBookFilePath() {
+            return addressBookFilePath;
+        }
     }
 
 }

--- a/src/test/java/seedu/resireg/model/alias/AliasTest.java
+++ b/src/test/java/seedu/resireg/model/alias/AliasTest.java
@@ -1,0 +1,46 @@
+package seedu.resireg.model.alias;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.resireg.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.resireg.logic.commands.AddCommand;
+import seedu.resireg.logic.commands.ListCommand;
+
+class AliasTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Alias(null));
+    }
+
+    @Test
+    public void constructor_invalidFloor_throwsIllegalArgumentException() {
+        String invalidFloor = "";
+        assertThrows(IllegalArgumentException.class, () -> new Alias(invalidFloor));
+    }
+
+    @Test
+    void isValidAlias() {
+        // null alias
+        assertThrows(NullPointerException.class, () -> Alias.isValidAlias(null));
+
+        // invalid alias
+        assertFalse(Alias.isValidAlias("")); // empty string
+        assertFalse(Alias.isValidAlias(" ")); // spaces only
+        assertFalse(Alias.isValidAlias("123")); // contains 3 digits
+        assertFalse(Alias.isValidAlias("01")); // starts with 0
+        assertFalse(Alias.isValidAlias(AddCommand.COMMAND_WORD)); // only non-numeric characters
+        assertFalse(Alias.isValidAlias(ListCommand.COMMAND_WORD)); // contains non-numeric characters
+        assertFalse(Alias.isValidAlias("two words")); // contains multiple words
+
+
+        // valid alias
+        assertTrue(Alias.isValidAlias("ro")); // 2 digits
+        assertTrue(Alias.isValidAlias("stu")); // 1 digit
+
+    }
+
+}

--- a/src/test/java/seedu/resireg/model/alias/CommandWordAliasTest.java
+++ b/src/test/java/seedu/resireg/model/alias/CommandWordAliasTest.java
@@ -1,0 +1,44 @@
+package seedu.resireg.model.alias;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ALIAS_STUDENTS_ST;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_COMMAND_STUDENTS_ST;
+import static seedu.resireg.testutil.TypicalCommandWordAliases.ROOMS_R;
+import static seedu.resireg.testutil.TypicalCommandWordAliases.STUDENTS_ST;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.resireg.testutil.CommandWordAliasBuilder;
+
+public class CommandWordAliasTest {
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        CommandWordAlias roomsCopy = new CommandWordAliasBuilder(ROOMS_R).build();
+        assertTrue(ROOMS_R.equals(roomsCopy));
+
+        // same object -> returns true
+        assertTrue(ROOMS_R.equals(ROOMS_R));
+
+        // null -> returns false
+        assertFalse(ROOMS_R.equals(null));
+
+        // different type -> returns false
+        assertFalse(ROOMS_R.equals(5));
+
+        // different student -> returns false
+        assertFalse(ROOMS_R.equals(STUDENTS_ST));
+
+        // different command word -> returns false
+        CommandWordAlias editedRoomAlias = new CommandWordAliasBuilder(ROOMS_R)
+            .withCommandWord(VALID_COMMAND_STUDENTS_ST).build();
+        assertFalse(ROOMS_R.equals(editedRoomAlias));
+
+        // different alias -> returns false
+        editedRoomAlias = new CommandWordAliasBuilder(ROOMS_R).withAlias(VALID_ALIAS_STUDENTS_ST).build();
+        assertFalse(ROOMS_R.equals(editedRoomAlias));
+
+    }
+}

--- a/src/test/java/seedu/resireg/model/alias/CommandWordTest.java
+++ b/src/test/java/seedu/resireg/model/alias/CommandWordTest.java
@@ -1,0 +1,45 @@
+package seedu.resireg.model.alias;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.resireg.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.resireg.logic.commands.AddCommand;
+import seedu.resireg.logic.commands.ListCommand;
+
+class CommandWordTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new CommandWord(null));
+    }
+
+    @Test
+    public void constructor_invalidFloor_throwsIllegalArgumentException() {
+        String invalidCommandWord = "";
+        assertThrows(IllegalArgumentException.class, () -> new CommandWord(invalidCommandWord));
+    }
+
+    @Test
+    void isValidCommandWord() {
+        // null command word
+        assertThrows(NullPointerException.class, () -> CommandWord.isValidCommandWord(null));
+
+        // invalid command word
+        assertFalse(CommandWord.isValidCommandWord("")); // empty string
+        assertFalse(CommandWord.isValidCommandWord(" ")); // spaces only
+        assertFalse(CommandWord.isValidCommandWord("123")); // contains 3 digits
+        assertFalse(CommandWord.isValidCommandWord("01")); // starts with 0
+        assertFalse(CommandWord.isValidCommandWord("two words")); // contains multiple words
+
+
+        // valid command word
+        assertTrue(CommandWord.isValidCommandWord(AddCommand.COMMAND_WORD)); // 2 digits
+        assertTrue(CommandWord.isValidCommandWord(ListCommand.COMMAND_WORD)); // 1 digit
+        assertFalse(CommandWord.isValidCommandWord(AddCommand.COMMAND_WORD + " ")); // only non-numeric characters
+        assertFalse(CommandWord.isValidCommandWord(ListCommand.COMMAND_WORD + "\t")); // contains non-numeric characters
+    }
+
+}

--- a/src/test/java/seedu/resireg/model/student/StudentIdTest.java
+++ b/src/test/java/seedu/resireg/model/student/StudentIdTest.java
@@ -6,8 +6,6 @@ import static seedu.resireg.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.resireg.model.student.faculty.Faculty;
-
 public class StudentIdTest {
 
     @Test
@@ -18,20 +16,20 @@ public class StudentIdTest {
     @Test
     public void constructor_invalidAddress_throwsIllegalArgumentException() {
         String invalidStudentId = "";
-        assertThrows(IllegalArgumentException.class, () -> new Faculty(invalidStudentId));
+        assertThrows(IllegalArgumentException.class, () -> new StudentId((invalidStudentId)));
     }
 
     @Test
-    public void isValidFaculty() {
+    public void isValidStudentId() {
         // null student ID
-        assertThrows(NullPointerException.class, () -> Faculty.isValidFaculty(null));
+        assertThrows(NullPointerException.class, () -> StudentId.isValidStudentId((null)));
 
         // invalid student IDs
-        assertFalse(Faculty.isValidFaculty("")); // empty string
-        assertFalse(Faculty.isValidFaculty(" ")); // spaces only
-        assertFalse(Faculty.isValidFaculty("e")); // missing "0" and 6 digits
-        assertFalse(Faculty.isValidFaculty("E0")); // missing 6 digits
-        assertFalse(Faculty.isValidFaculty("E012345")); // only 5 digits
+        assertFalse(StudentId.isValidStudentId((""))); // empty string
+        assertFalse(StudentId.isValidStudentId((" "))); // spaces only
+        assertFalse(StudentId.isValidStudentId(("e"))); // missing "0" and 6 digits
+        assertFalse(StudentId.isValidStudentId(("E0"))); // missing 6 digits
+        assertFalse(StudentId.isValidStudentId(("E012345"))); // only 5 digits
 
 
         // valid student IDs

--- a/src/test/java/seedu/resireg/storage/JsonAdaptedCommandWordAliasTest.java
+++ b/src/test/java/seedu/resireg/storage/JsonAdaptedCommandWordAliasTest.java
@@ -1,0 +1,60 @@
+package seedu.resireg.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.resireg.storage.JsonAdaptedCommandWordAlias.MISSING_FIELD_MESSAGE_FORMAT;
+import static seedu.resireg.testutil.Assert.assertThrows;
+import static seedu.resireg.testutil.TypicalCommandWordAliases.ROOMS_R;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.resireg.commons.exceptions.IllegalValueException;
+import seedu.resireg.logic.commands.AddCommand;
+import seedu.resireg.model.alias.Alias;
+import seedu.resireg.model.alias.CommandWord;
+
+public class JsonAdaptedCommandWordAliasTest {
+    private static final String INVALID_COMMAND_WORD = "3482ndn";
+    private static final String INVALID_ALIAS = AddCommand.COMMAND_WORD;
+
+    private static final String VALID_COMMAND_WORD = ROOMS_R.getCommandWord().toString();
+    private static final String VALID_ALIAS = ROOMS_R.getAlias().toString();
+
+    @Test
+    public void toModelType_validCommandWordAliasDetails_returnsCommandWordAlias() throws Exception {
+        JsonAdaptedCommandWordAlias commandWordAlias = new JsonAdaptedCommandWordAlias(ROOMS_R);
+        assertEquals(ROOMS_R, commandWordAlias.toModelType());
+    }
+
+    @Test
+    public void toModelType_invalidCommandWord_throwsIllegalValueException() {
+        JsonAdaptedCommandWordAlias commandWordAlias =
+            new JsonAdaptedCommandWordAlias(INVALID_COMMAND_WORD, VALID_ALIAS);
+        String expectedMessage = CommandWord.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, commandWordAlias::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullCommandWord_throwsIllegalValueException() {
+        JsonAdaptedCommandWordAlias commandWordAlias =
+            new JsonAdaptedCommandWordAlias(null, VALID_ALIAS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, CommandWord.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, commandWordAlias::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidAlias_throwsIllegalValueException() {
+        JsonAdaptedCommandWordAlias commandWordAlias =
+            new JsonAdaptedCommandWordAlias(VALID_COMMAND_WORD, INVALID_ALIAS);
+        String expectedMessage = Alias.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, commandWordAlias::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullAlias_throwsIllegalValueException() {
+        JsonAdaptedCommandWordAlias commandWordAlias =
+            new JsonAdaptedCommandWordAlias(VALID_COMMAND_WORD, null);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Alias.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, commandWordAlias::toModelType);
+    }
+}
+

--- a/src/test/java/seedu/resireg/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/resireg/storage/JsonUserPrefsStorageTest.java
@@ -57,12 +57,6 @@ public class JsonUserPrefsStorageTest {
     }
 
     @Test
-    public void readUserPrefs_valuesMissingFromFile_defaultValuesUsed() throws DataConversionException {
-        UserPrefs actual = readUserPrefs("EmptyUserPrefs.json").get();
-        assertEquals(new UserPrefs(), actual);
-    }
-
-    @Test
     public void readUserPrefs_extraValuesInFile_extraValuesIgnored() throws DataConversionException {
         UserPrefs expected = getTypicalUserPrefs();
         UserPrefs actual = readUserPrefs("ExtraValuesUserPref.json").get();

--- a/src/test/java/seedu/resireg/testutil/CommandWordAliasBuilder.java
+++ b/src/test/java/seedu/resireg/testutil/CommandWordAliasBuilder.java
@@ -1,0 +1,56 @@
+package seedu.resireg.testutil;
+
+import seedu.resireg.model.alias.Alias;
+import seedu.resireg.model.alias.CommandWord;
+import seedu.resireg.model.alias.CommandWordAlias;
+
+/**
+ * A utility class to help with building Student objects.
+ */
+public class CommandWordAliasBuilder {
+
+    public static final String DEFAULT_COMMAND_WORD = "rooms";
+    public static final String DEFAULT_ALIAS = "r";
+
+    private CommandWord commandWord;
+    private Alias alias;
+
+
+    /**
+     * Creates a {@code RoomBuilder} with the default details.
+     */
+    public CommandWordAliasBuilder() {
+        commandWord = new CommandWord(DEFAULT_COMMAND_WORD);
+        alias = new Alias(DEFAULT_ALIAS);
+    }
+
+    /**
+     * Initializes the RoomBuilder with the data of {@code roomToCopy}.
+     */
+    public CommandWordAliasBuilder(CommandWordAlias commandWordAliasToCopy) {
+        commandWord = commandWordAliasToCopy.getCommandWord();
+        alias = commandWordAliasToCopy.getAlias();
+    }
+
+    /**
+     * Sets the {@code Floor} of the {@code Room} that we are building.
+     */
+    public CommandWordAliasBuilder withCommandWord(String commandWord) {
+        this.commandWord = new CommandWord(commandWord);
+        return this;
+    }
+
+    /**
+     * Sets the {@code RoomType} of the {@code Student} that we are building.
+     */
+    public CommandWordAliasBuilder withAlias(String alias) {
+        this.alias = new Alias(alias);
+        return this;
+    }
+
+
+    public CommandWordAlias build() {
+        return new CommandWordAlias(commandWord, alias);
+    }
+
+}

--- a/src/test/java/seedu/resireg/testutil/TypicalCommandWordAliases.java
+++ b/src/test/java/seedu/resireg/testutil/TypicalCommandWordAliases.java
@@ -1,0 +1,62 @@
+package seedu.resireg.testutil;
+
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ALIAS_ROOMS_RO;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ALIAS_STUDENTS_ST;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_COMMAND_ROOMS_RO;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_COMMAND_STUDENTS_ST;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.resireg.model.ReadOnlyUserPrefs;
+import seedu.resireg.model.UserPrefs;
+import seedu.resireg.model.alias.CommandWordAlias;
+
+/**
+ * A utility class containing a list of {@code Student} objects to be used in tests.
+ */
+public class TypicalCommandWordAliases {
+
+    public static final CommandWordAlias ROOMS_R = new CommandWordAliasBuilder().withCommandWord("rooms")
+        .withAlias("r").build();
+    public static final CommandWordAlias STUDENTS_STU = new CommandWordAliasBuilder().withCommandWord("students")
+        .withAlias("stu").build();
+    public static final CommandWordAlias ALLOCATE_AL = new CommandWordAliasBuilder().withCommandWord("allocate")
+        .withAlias("al").build();
+    public static final CommandWordAlias FIND_FI = new CommandWordAliasBuilder().withCommandWord("find")
+        .withAlias("fi").build();
+    public static final CommandWordAlias REALLOCATE_REL = new CommandWordAliasBuilder().withCommandWord("reallocate")
+        .withAlias("rel").build();
+
+    // Manually added
+    public static final CommandWordAlias EDIT_E = new CommandWordAliasBuilder().withCommandWord("edit")
+        .withAlias("e").build();
+    public static final CommandWordAlias DELETE_D = new CommandWordAliasBuilder().withCommandWord("delete")
+        .withAlias("d").build();
+
+    // Manually added - Student's details found in {@code CommandTestUtil}
+    public static final CommandWordAlias ROOMS_RO = new CommandWordAliasBuilder()
+        .withCommandWord(VALID_COMMAND_ROOMS_RO)
+        .withAlias(VALID_ALIAS_ROOMS_RO).build();
+    public static final CommandWordAlias STUDENTS_ST = new CommandWordAliasBuilder()
+        .withCommandWord(VALID_COMMAND_STUDENTS_ST)
+        .withAlias(VALID_ALIAS_STUDENTS_ST).build();
+
+    private TypicalCommandWordAliases() {} // prevents instantiation
+
+    /**
+     * Returns an {@code UserPrefs} with all the typical command word aliases.
+     */
+    public static ReadOnlyUserPrefs getTypicalUserPrefs() {
+        UserPrefs userPrefs = new UserPrefs();
+        for (CommandWordAlias commandWordAlias : getTypicalCommandWordAliases()) {
+            userPrefs.addAlias(commandWordAlias);
+        }
+        return userPrefs;
+    }
+
+    public static List<CommandWordAlias> getTypicalCommandWordAliases() {
+        return new ArrayList<>(Arrays.asList(ROOMS_R, STUDENTS_STU, ALLOCATE_AL, FIND_FI, REALLOCATE_REL));
+    }
+}

--- a/src/test/java/seedu/resireg/testutil/UserPrefsBuilder.java
+++ b/src/test/java/seedu/resireg/testutil/UserPrefsBuilder.java
@@ -1,0 +1,34 @@
+package seedu.resireg.testutil;
+
+import seedu.resireg.model.UserPrefs;
+import seedu.resireg.model.alias.CommandWordAlias;
+
+/**
+ * A utility class to help with building UserPrefs objects.
+ * Example usage: <br>
+ *     {@code UserPrefs up = new UserPrefsBuilder().withCommandWordAlias([object]).build();}
+ */
+public class UserPrefsBuilder {
+
+    private UserPrefs userPrefs;
+
+    public UserPrefsBuilder() {
+        userPrefs = new UserPrefs();
+    }
+
+    public UserPrefsBuilder(UserPrefs userPrefs) {
+        this.userPrefs = userPrefs;
+    }
+
+    /**
+     * Adds a new {@code CommandWordAlias} to the {@code UserPrefs} that we are building.
+     */
+    public UserPrefsBuilder withCommandWordAlias(CommandWordAlias commandWordAlias) {
+        userPrefs.addAlias(commandWordAlias);
+        return this;
+    }
+
+    public UserPrefs build() {
+        return userPrefs;
+    }
+}


### PR DESCRIPTION
### What this does
This PR adds aliasing to ResiReg, namely 3 commands: 
- `alias` : Adds an alias. Format: `alias c/<command> a/<alias>` e.g. `alias c/rooms a/r`
- `dealias` : Deletes an alias. E.g. `dealias c/rooms a/r`
- `aliases` : Lists all aliases. Format: `aliases`

### How to test
<!-- Write an essay here if it's more suitable -->
1. Launch the application.
2. Type in the above 3 commands. 
3. Note that you can't have the same alias for different commands, an alias cannot be a command word, and undo/redo don't apply to alias commands (because they do not change the state of ResiReg). 

### Notes
Added a lot of testing in this PR. Note to team-mates: please add Integration tests for the commands you've added to ResiReg by this weekend - it takes a LOT of work. 

Fixes #103 