### PR TITLE
Add side by side split view

### DIFF
--- a/src/main/java/seedu/resireg/logic/CommandMapper.java
+++ b/src/main/java/seedu/resireg/logic/CommandMapper.java
@@ -24,6 +24,7 @@ import seedu.resireg.logic.commands.ListCommand;
 import seedu.resireg.logic.commands.ListRoomCommand;
 import seedu.resireg.logic.commands.ReallocateCommand;
 import seedu.resireg.logic.commands.RedoCommand;
+import seedu.resireg.logic.commands.ToggleMainPanelCommand;
 import seedu.resireg.logic.commands.UndoCommand;
 import seedu.resireg.logic.parser.AddAliasCommandParser;
 import seedu.resireg.logic.parser.AddCommandParser;
@@ -78,6 +79,8 @@ public class CommandMapper {
         commandMap.addCommand(DeleteAliasCommand.COMMAND_WORD, DeleteAliasCommand.HELP,
             new DeleteAliasCommandParser()::parse);
         commandMap.addCommand(ListAliasCommand.COMMAND_WORD, ListAliasCommand.HELP, unused -> new ListAliasCommand());
+        commandMap.addCommand(ToggleMainPanelCommand.COMMAND_WORD, ToggleMainPanelCommand.HELP,
+            unused -> new ToggleMainPanelCommand());
 
 
         for (CommandWordAlias commandWordAlias : aliases) {

--- a/src/main/java/seedu/resireg/logic/commands/CommandWordEnum.java
+++ b/src/main/java/seedu/resireg/logic/commands/CommandWordEnum.java
@@ -17,7 +17,8 @@ public enum CommandWordEnum {
     UNDO_COMMAND("undo"),
     ADD_ALIAS_COMMAND("alias"),
     DELETE_ALIAS_COMMAND("dealias"),
-    LIST_ALIAS_COMMAND("aliases");
+    LIST_ALIAS_COMMAND("aliases"),
+    TOGGLE_MAIN_PANEL_COMMAND("toggleview");
 
     private String commandWord;
 

--- a/src/main/java/seedu/resireg/logic/commands/ToggleMainPanelCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ToggleMainPanelCommand.java
@@ -1,0 +1,21 @@
+package seedu.resireg.logic.commands;
+
+import seedu.resireg.model.Model;
+import seedu.resireg.storage.Storage;
+
+/**
+ * Toggles the UI layout betweenn a tabbed view and a side-by-side split view.
+ */
+public class ToggleMainPanelCommand extends Command {
+    public static final String COMMAND_WORD = CommandWordEnum.TOGGLE_MAIN_PANEL_COMMAND.toString();
+
+    public static final String MESSAGE_SUCCESS = "Switched main panel layout.";
+
+    public static final Help HELP = new Help(COMMAND_WORD,
+            "Toggles the main panel layout between a tabbed view and a split view.");
+
+    @Override
+    public CommandResult execute(Model model, Storage storage) {
+        return new ToggleMainPanelCommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/resireg/logic/commands/ToggleMainPanelCommandResult.java
+++ b/src/main/java/seedu/resireg/logic/commands/ToggleMainPanelCommandResult.java
@@ -1,0 +1,19 @@
+package seedu.resireg.logic.commands;
+
+import seedu.resireg.ui.MainWindow;
+
+public class ToggleMainPanelCommandResult extends CommandResult {
+
+    /**
+     * Constructs a {@code ToggleCommandResult} with the specified {@code feedbackToUser},
+     * that will toggle the UI layout between a tabbed layout and a side-by-side split view.
+     */
+    public ToggleMainPanelCommandResult(String feedbackToUser) {
+        super(feedbackToUser);
+    }
+
+    @Override
+    public void displayResult(MainWindow mainWindow) {
+        mainWindow.toggleMainPanelLayout();
+    }
+}

--- a/src/main/java/seedu/resireg/ui/MainPanel.java
+++ b/src/main/java/seedu/resireg/ui/MainPanel.java
@@ -1,0 +1,47 @@
+package seedu.resireg.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import seedu.resireg.logic.Logic;
+import seedu.resireg.logic.commands.TabView;
+
+/**
+ * Represents the main panel containing the room list and student list of the {@code MainWindow}.
+ */
+public abstract class MainPanel extends UiPart<Region> {
+    protected StudentListPanel studentListPanel;
+    protected RoomListPanel roomListPanel;
+
+    @FXML
+    protected StackPane studentListPanelPlaceholder;
+    @FXML
+    protected StackPane roomListPanelPlaceholder;
+
+    public MainPanel(String fxmlFileName) {
+        super(fxmlFileName);
+    }
+
+    final void updatePanels(Logic logic) {
+        studentListPanel = new StudentListPanel(
+                logic.getFilteredStudentList(),
+                logic.getFilteredAllocationList(),
+                logic.getFilteredRoomList());
+        studentListPanelPlaceholder.getChildren()
+                .add(studentListPanel.getRoot());
+
+        roomListPanel = new RoomListPanel(
+                logic.getFilteredRoomList(),
+                logic.getFilteredAllocationList(),
+                logic.getFilteredStudentList());
+        roomListPanelPlaceholder.getChildren()
+                .add(roomListPanel.getRoot());
+    }
+
+    /**
+     * Sets what is displayed in the listPanelStackPane based on the toggle.
+     *
+     * @param toggleView enum representing what should be displayed
+     */
+    abstract void handleToggle(TabView toggleView);
+}

--- a/src/main/java/seedu/resireg/ui/MainWindow.java
+++ b/src/main/java/seedu/resireg/ui/MainWindow.java
@@ -5,8 +5,6 @@ import java.util.logging.Logger;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
-import javafx.scene.control.Tab;
-import javafx.scene.control.TabPane;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
@@ -34,10 +32,9 @@ public class MainWindow extends UiPart<Stage> {
     private Logic logic;
 
     // Independent Ui parts residing in this Ui container
-    private StudentListPanel studentListPanel;
-    private RoomListPanel roomListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
+    private MainPanel mainPanel;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -49,10 +46,7 @@ public class MainWindow extends UiPart<Stage> {
     private StackPane semesterDisplayPlaceholder;
 
     @FXML
-    private StackPane studentListPanelPlaceholder;
-
-    @FXML
-    private StackPane roomListPanelPlaceholder;
+    private StackPane mainPanelPlaceholder;
 
     @FXML
     private StackPane resultDisplayPlaceholder;
@@ -60,14 +54,6 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private StackPane statusbarPlaceholder;
 
-    @FXML
-    private TabPane tabPane;
-
-    @FXML
-    private Tab studentsTab;
-
-    @FXML
-    private Tab roomsTab;
 
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
@@ -130,7 +116,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        updatePanels();
+        setMainPanel(new TabbedView());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -170,27 +156,6 @@ public class MainWindow extends UiPart<Stage> {
         }
     }
 
-    /**
-     * Sets what is displayed in the listPanelStackPane based on the toggle.
-     *
-     * @param toggleView enum representing what should be displayed
-     */
-    public void handleToggle(TabView toggleView) {
-        if (toggleView == TabView.ROOMS) {
-            showRoomsPanel();
-        } else {
-            showStudentPanel();
-        }
-    }
-
-    private void showStudentPanel() {
-        tabPane.getSelectionModel().select(studentsTab);
-    }
-
-    private void showRoomsPanel() {
-        tabPane.getSelectionModel().select(roomsTab);
-    }
-
     void show() {
         primaryStage.show();
     }
@@ -207,8 +172,31 @@ public class MainWindow extends UiPart<Stage> {
         primaryStage.hide();
     }
 
-    public StudentListPanel getStudentListPanel() {
-        return studentListPanel;
+    private void setMainPanel(MainPanel mainPanel) {
+        this.mainPanel = mainPanel;
+        mainPanelPlaceholder.getChildren().clear();
+        mainPanelPlaceholder.getChildren().add(mainPanel.getRoot());
+        mainPanel.updatePanels(logic);
+    }
+
+    /**
+     * Sets what is displayed in the listPanelStackPane based on the toggle.
+     *
+     * @param toggleView enum representing what should be displayed
+     */
+    public void handleToggle(TabView toggleView) {
+        mainPanel.handleToggle(toggleView);
+    }
+
+    /**
+     * Toggles the layout of the main panel between a tabbed layout and the side-by-side split layout.
+     */
+    public void toggleMainPanelLayout() {
+        if (mainPanel instanceof TabbedView) {
+            setMainPanel(new SplitView());
+        } else {
+            setMainPanel(new TabbedView());
+        }
     }
 
     /**
@@ -232,7 +220,7 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
-            updatePanels();
+            mainPanel.updatePanels(logic);
 
             return commandResult;
         } catch (CommandException | ParseException e) {
@@ -240,24 +228,5 @@ public class MainWindow extends UiPart<Stage> {
             resultDisplay.setFeedbackToUser(commandText, e.getMessage(), true);
             throw e;
         }
-    }
-
-    /**
-     * Updates the panels for Student and Room lists for changes visually.
-     */
-    private void updatePanels() {
-        studentListPanel = new StudentListPanel(
-                logic.getFilteredStudentList(),
-                logic.getFilteredAllocationList(),
-                logic.getFilteredRoomList());
-        studentListPanelPlaceholder.getChildren()
-                .add(studentListPanel.getRoot());
-
-        roomListPanel = new RoomListPanel(
-                logic.getFilteredRoomList(),
-                logic.getFilteredAllocationList(),
-                logic.getFilteredStudentList());
-        roomListPanelPlaceholder.getChildren()
-                .add(roomListPanel.getRoot());
     }
 }

--- a/src/main/java/seedu/resireg/ui/SplitView.java
+++ b/src/main/java/seedu/resireg/ui/SplitView.java
@@ -1,0 +1,16 @@
+package seedu.resireg.ui;
+
+import seedu.resireg.logic.commands.TabView;
+
+public class SplitView extends MainPanel {
+    private static final String FXML = "SplitView.fxml";
+
+    public SplitView() {
+        super(FXML);
+    }
+
+    @Override
+    void handleToggle(TabView toggleView) {
+        // do nothing, since all tabs are already displayed
+    }
+}

--- a/src/main/java/seedu/resireg/ui/TabbedView.java
+++ b/src/main/java/seedu/resireg/ui/TabbedView.java
@@ -1,0 +1,40 @@
+package seedu.resireg.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import seedu.resireg.logic.commands.TabView;
+
+public class TabbedView extends MainPanel {
+    private static final String FXML = "TabbedView.fxml";
+
+    @FXML
+    private TabPane tabPane;
+
+    @FXML
+    private Tab studentsTab;
+
+    @FXML
+    private Tab roomsTab;
+
+    public TabbedView() {
+        super(FXML);
+    }
+
+    private void showStudentPanel() {
+        tabPane.getSelectionModel().select(studentsTab);
+    }
+
+    private void showRoomsPanel() {
+        tabPane.getSelectionModel().select(roomsTab);
+    }
+
+    @Override
+    void handleToggle(TabView toggleView) {
+        if (toggleView == TabView.ROOMS) {
+            showRoomsPanel();
+        } else {
+            showStudentPanel();
+        }
+    }
+}

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -329,6 +329,12 @@
     -fx-padding: 8 1 8 1;
 }
 
+.split-view-title {
+    -fx-font-size: 13pt;
+    -fx-text-fill: white;
+    -fx-label-padding: 4 12 4 12;
+}
+
 #cardPane {
     -fx-background-color: transparent;
     -fx-border-width: 0;

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -39,6 +39,7 @@
                     <RowConstraints vgrow="NEVER"/>
                     <RowConstraints vgrow="ALWAYS"/>
                     <RowConstraints/>
+                    <RowConstraints/>
                 </rowConstraints>
 
                 <MenuBar fx:id="menuBar"
@@ -66,40 +67,16 @@
                     </padding>
                 </StackPane>
 
-                <TabPane fx:id="tabPane"
-                         tabClosingPolicy="UNAVAILABLE"
-                         GridPane.columnIndex="1" GridPane.rowIndex="2" GridPane.rowSpan="2">
-
-                    <!-- Students tab -->
-                    <Tab fx:id="studentsTab" text="Students">
-                        <VBox fx:id="studentList"
-                              VBox.vgrow="ALWAYS"
-                              styleClass="pane-with-border"
-                              minWidth="340" prefWidth="340">
-                            <padding>
-                                <Insets top="10" right="10" bottom="10" left="10"/>
-                            </padding>
-                            <StackPane fx:id="studentListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-                        </VBox>
-                    </Tab>
-                    <!-- Rooms tab -->
-                    <Tab fx:id="roomsTab" text="Rooms">
-                        <VBox fx:id="roomList"
-                              VBox.vgrow="ALWAYS"
-                              styleClass="pane-with-border"
-                              minWidth="340" prefWidth="340">
-                            <padding>
-                                <Insets top="10" right="10" bottom="10" left="10"/>
-                            </padding>
-                            <StackPane fx:id="roomListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-                        </VBox>
-                    </Tab>
-                </TabPane>
+                <StackPane fx:id="mainPanelPlaceholder"
+                            VBox.vgrow="ALWAYS"
+                            styleClass="pane-with-border"
+                            GridPane.rowSpan="1" GridPane.columnSpan="1" GridPane.rowIndex="2" GridPane.columnIndex="1">
+                </StackPane>
 
                 <StackPane fx:id="commandBoxPlaceholder"
                            VBox.vgrow="NEVER"
                            styleClass="pane-with-border"
-                           GridPane.columnIndex="0" GridPane.rowIndex="4" GridPane.columnSpan="2">
+                           GridPane.columnIndex="0" GridPane.rowIndex="3" GridPane.columnSpan="2">
                     <padding>
                         <Insets top="5" right="10" bottom="5" left="10"/>
                     </padding>
@@ -107,7 +84,7 @@
 
                 <StackPane fx:id="statusbarPlaceholder"
                            VBox.vgrow="NEVER"
-                           GridPane.columnIndex="0" GridPane.rowIndex="5" GridPane.columnSpan="2"/>
+                           GridPane.columnIndex="0" GridPane.rowIndex="4" GridPane.columnSpan="2"/>
             </GridPane>
         </Scene>
     </scene>

--- a/src/main/resources/view/SplitView.fxml
+++ b/src/main/resources/view/SplitView.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.StackPane?>
+<HBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+    <StackPane fx:id="studentListPanelPlaceholder" HBox.hgrow="ALWAYS"/>
+    <StackPane fx:id="roomListPanelPlaceholder" HBox.hgrow="ALWAYS"/>
+</HBox>

--- a/src/main/resources/view/SplitView.fxml
+++ b/src/main/resources/view/SplitView.fxml
@@ -2,7 +2,15 @@
 
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.Label?>
 <HBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-    <StackPane fx:id="studentListPanelPlaceholder" HBox.hgrow="ALWAYS"/>
-    <StackPane fx:id="roomListPanelPlaceholder" HBox.hgrow="ALWAYS"/>
+    <VBox HBox.hgrow="ALWAYS" >
+        <Label VBox.vgrow="NEVER" styleClass="split-view-title">Students</Label>
+        <StackPane fx:id="studentListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+    </VBox>
+    <VBox HBox.hgrow="ALWAYS" >
+        <Label VBox.vgrow="NEVER" styleClass="split-view-title">Rooms</Label>
+        <StackPane fx:id="roomListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+    </VBox>
 </HBox>

--- a/src/main/resources/view/TabbedView.fxml
+++ b/src/main/resources/view/TabbedView.fxml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.VBox?>
+
+<?import javafx.scene.control.Tab?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.TabPane?>
+
+<StackPane xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+
+    <TabPane fx:id="tabPane"
+             tabClosingPolicy="UNAVAILABLE">
+
+        <!-- Students tab -->
+        <Tab fx:id="studentsTab" text="Students">
+            <VBox fx:id="studentList"
+                  VBox.vgrow="ALWAYS"
+                  styleClass="pane-with-border"
+                  minWidth="340" prefWidth="340">
+                <padding>
+                    <Insets top="10" right="10" bottom="10" left="10"/>
+                </padding>
+                <StackPane fx:id="studentListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+            </VBox>
+        </Tab>
+
+        <!-- Rooms tab -->
+        <Tab fx:id="roomsTab" text="Rooms">
+            <VBox fx:id="roomList"
+                  VBox.vgrow="ALWAYS"
+                  styleClass="pane-with-border"
+                  minWidth="340" prefWidth="340">
+                <padding>
+                    <Insets top="10" right="10" bottom="10" left="10"/>
+                </padding>
+                <StackPane fx:id="roomListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+            </VBox>
+        </Tab>
+    </TabPane>
+
+</StackPane>


### PR DESCRIPTION
### What this does
This PR adds a new side by side view for the rooms and students, and allows the user to toggle between the existing tabbed view and new side by side view using the `toggleview` command. The default view is still the tabbed view.

Side by side view:
![image](https://user-images.githubusercontent.com/43085850/97100754-d60bb700-16d1-11eb-8172-a8feefd32c66.png)

Closes #95 

To do in another PR:
- Update user guide.
- Add/update use cases.

### How to test
1. Start the app. It should be in the tabbed view.
To verify view toggling works:
1. Enter the command `toggleview`. The app should show the students and rooms side by side.
1. Enter `toggleview` again. The tabbed view should be shown again.
To verify the tabs still work:
1. Enter the `rooms` command. The app should switch to the rooms tab.
1. Enter the `students` command. The app should switch back to the students tab.
To verify that the view does not get toggled by other commands when in the side by side view:
1. Enter the command `toggleview` to switch to the side by side view.
1. Enter the `rooms` command. The app should remain in the side by side view.
1. Enter the `students` command. The app should remain in the side by side view.


### Notes
<!-- Anything else we should take note of, e.g. how this affects future PRs,
issues faced, etc. -->
