### PR TITLE
Functionality Increment: Add Command History

### DIFF
--- a/src/main/java/seedu/resireg/commons/util/InvalidationListenerList.java
+++ b/src/main/java/seedu/resireg/commons/util/InvalidationListenerList.java
@@ -1,0 +1,51 @@
+package seedu.resireg.commons.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+
+import javafx.beans.InvalidationListener;
+import javafx.beans.Observable;
+
+/**
+ * Manages a list of {@link InvalidationListener} objects. Created so that
+ * the history will still be updated despite potential storage issues.
+ */
+public class InvalidationListenerList {
+    private final ArrayList<InvalidationListener> listeners = new ArrayList<>();
+
+    /**
+     * Calls {@link InvalidationListener#invalidated(Observable)} on all added listeners.
+     * Any modifications to the list during the invocation of this method
+     * will only take effect on the next invocation.
+     *
+     * @param obs The {@code Observable} that became invalid.
+     */
+    public void callListeners(Observable obs) {
+        ArrayList<InvalidationListener> copy = new ArrayList<>(listeners);
+
+        for (InvalidationListener listener : copy) {
+            listener.invalidated(obs);
+        }
+    }
+
+    /**
+     * Adds {@code listener} to the list of listeners.
+     * If the same listener is added multiple times, it will be notified multiple times as well.
+     */
+    public void addListener(InvalidationListener listener) {
+        requireNonNull(listener);
+        listeners.add(listener);
+    }
+
+    /**
+     * Removes {@code listener} from the list of listeners.
+     * If the listener was not added previously, then this method does nothing.
+     * However, if the  listener was added multiple times, only the first occurrence will be removed.
+     */
+    public void removeListener(InvalidationListener listener) {
+        requireNonNull(listener);
+        listeners.remove(listener);
+    }
+
+}

--- a/src/main/java/seedu/resireg/logic/CommandHistory.java
+++ b/src/main/java/seedu/resireg/logic/CommandHistory.java
@@ -1,0 +1,58 @@
+package seedu.resireg.logic;
+
+import static java.util.Objects.requireNonNull;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+/**
+ * A class to store the history of previously executed commands.
+ */
+public class CommandHistory {
+    private final ObservableList<String> history = FXCollections.observableArrayList();
+    private final ObservableList<String> unmodifiableHistory =
+            FXCollections.unmodifiableObservableList(history);
+
+    public CommandHistory() {}
+
+    public CommandHistory(CommandHistory commandHistory) {
+        history.addAll(commandHistory.history);
+    }
+
+    /**
+     * Appends {@code input} to the list of input entered
+     */
+    public void add(String input) {
+        requireNonNull(input);
+        history.add(input);
+    }
+
+    /**
+     * Return unmodifiable view of {@code history}
+     */
+    public ObservableList<String> getHistory() {
+        return unmodifiableHistory;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        // short circuit if same object
+        if (o == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(o instanceof CommandHistory)) {
+            return false;
+        }
+
+        // state check
+        CommandHistory other = (CommandHistory) o;
+        return history.equals(other.history);
+    }
+
+    @Override
+    public int hashCode() {
+        return history.hashCode();
+    }
+}

--- a/src/main/java/seedu/resireg/logic/CommandMapper.java
+++ b/src/main/java/seedu/resireg/logic/CommandMapper.java
@@ -19,6 +19,7 @@ import seedu.resireg.logic.commands.ExitCommand;
 import seedu.resireg.logic.commands.FindCommand;
 import seedu.resireg.logic.commands.Help;
 import seedu.resireg.logic.commands.HelpCommand;
+import seedu.resireg.logic.commands.HistoryCommand;
 import seedu.resireg.logic.commands.ListAliasCommand;
 import seedu.resireg.logic.commands.ListCommand;
 import seedu.resireg.logic.commands.ListRoomCommand;
@@ -78,6 +79,7 @@ public class CommandMapper {
         commandMap.addCommand(DeleteAliasCommand.COMMAND_WORD, DeleteAliasCommand.HELP,
             new DeleteAliasCommandParser()::parse);
         commandMap.addCommand(ListAliasCommand.COMMAND_WORD, ListAliasCommand.HELP, unused -> new ListAliasCommand());
+        commandMap.addCommand(HistoryCommand.COMMAND_WORD, HistoryCommand.HELP, unused -> new HistoryCommand());
 
 
         for (CommandWordAlias commandWordAlias : aliases) {

--- a/src/main/java/seedu/resireg/logic/Logic.java
+++ b/src/main/java/seedu/resireg/logic/Logic.java
@@ -46,6 +46,12 @@ public interface Logic {
     ObservableList<Allocation> getFilteredAllocationList();
 
     /**
+     * Returns an unmodifiable view of the list of commands entered by the user.
+     * The list is ordered in reverse chronological order.
+     */
+    ObservableList<String> getHistory();
+
+    /**
      * Returns the user prefs' ResiReg file path.
      */
     Path getResiRegFilePath();

--- a/src/main/java/seedu/resireg/logic/LogicManager.java
+++ b/src/main/java/seedu/resireg/logic/LogicManager.java
@@ -29,7 +29,9 @@ public class LogicManager implements Logic {
 
     private final Model model;
     private final Storage storage;
+    private final CommandHistory history;
     private ResiRegParser resiRegParser; // mutable, to allow for dynamic aliasing
+    private boolean isModified;
 
     /**
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
@@ -37,22 +39,33 @@ public class LogicManager implements Logic {
     public LogicManager(Model model, Storage storage) {
         this.model = model;
         this.storage = storage;
+        this.history = new CommandHistory();
+
+        model.getResiReg().addListener(observable -> isModified = true);
     }
 
     @Override
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
+        isModified = false;
 
         CommandResult commandResult;
-        resiRegParser = new CommandMapper(model.getCommandWordAliases()).getParser();
-        Command command = resiRegParser.parseCommand(commandText);
-        commandResult = command.execute(model, storage);
-
         try {
-            storage.saveResiReg(model.getResiReg());
-            storage.saveUserPrefs(model.getUserPrefs());
-        } catch (IOException ioe) {
-            throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
+            resiRegParser = new CommandMapper(model.getCommandWordAliases()).getParser();
+            Command command = resiRegParser.parseCommand(commandText);
+            commandResult = command.execute(model, storage, history);
+        } finally {
+            history.add(commandText);
+        }
+
+        if (isModified) {
+            logger.info("Modification present. Saving to file.");
+            try {
+                storage.saveResiReg(model.getResiReg());
+                storage.saveUserPrefs(model.getUserPrefs());
+            } catch (IOException ioe) {
+                throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
+            }
         }
 
         return commandResult;
@@ -86,6 +99,11 @@ public class LogicManager implements Logic {
     @Override
     public Path getResiRegFilePath() {
         return model.getResiRegFilePath();
+    }
+
+    @Override
+    public ObservableList<String> getHistory() {
+        return history.getHistory();
     }
 
     @Override

--- a/src/main/java/seedu/resireg/logic/commands/AddAliasCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/AddAliasCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.resireg.logic.parser.CliSyntax.PREFIX_ALIAS;
 import static seedu.resireg.logic.parser.CliSyntax.PREFIX_COMMAND;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.alias.CommandWordAlias;
@@ -36,7 +37,7 @@ public class AddAliasCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws CommandException {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) throws CommandException {
         requireNonNull(model);
 
         if (model.hasCommandWordAlias(toAdd)) {

--- a/src/main/java/seedu/resireg/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/AddCommand.java
@@ -8,6 +8,7 @@ import static seedu.resireg.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.resireg.logic.parser.CliSyntax.PREFIX_STUDENT_ID;
 import static seedu.resireg.logic.parser.CliSyntax.PREFIX_TAG;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.student.Student;
@@ -50,7 +51,7 @@ public class AddCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws CommandException {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) throws CommandException {
         requireNonNull(model);
 
         if (model.hasStudent(toAdd)) {

--- a/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import seedu.resireg.commons.core.Messages;
 import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.CreateEditCopy;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
@@ -54,7 +55,7 @@ public class AllocateCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws CommandException {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) throws CommandException {
         requireNonNull(model);
         List<Student> lastShownListStudent = model.getFilteredStudentList();
         List<Room> lastShownListRoom = model.getFilteredRoomList();

--- a/src/main/java/seedu/resireg/logic/commands/ArchiveCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ArchiveCommand.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.logging.Logger;
 
 import seedu.resireg.commons.core.LogsCenter;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ReadOnlyResiReg;
@@ -23,7 +24,7 @@ public class ArchiveCommand extends Command {
     private final Logger logger = LogsCenter.getLogger(ArchiveCommand.class);
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws CommandException {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) throws CommandException {
         requireAllNonNull(model, storage);
         // Create the new semester
         ReadOnlyResiReg resiReg = model.getResiReg();

--- a/src/main/java/seedu/resireg/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ClearCommand.java
@@ -2,6 +2,7 @@ package seedu.resireg.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ResiReg;
 import seedu.resireg.storage.Storage;
@@ -17,7 +18,7 @@ public class ClearCommand extends Command {
     public static final Help HELP = new Help(COMMAND_WORD, "Clears all students and rooms.");
 
     @Override
-    public CommandResult execute(Model model, Storage storage) {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) {
         requireNonNull(model);
         model.setResiReg(new ResiReg());
         model.saveStateResiReg();

--- a/src/main/java/seedu/resireg/logic/commands/Command.java
+++ b/src/main/java/seedu/resireg/logic/commands/Command.java
@@ -1,5 +1,6 @@
 package seedu.resireg.logic.commands;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.storage.Storage;
@@ -14,9 +15,10 @@ public abstract class Command {
      *
      * @param model {@code Model} which the command should operate on.
      * @param storage {@code Storage} which the command can update.
+     * @param history {@code CommandHistory} which the command should operate on.
      * @return feedback message of the operation result for display
      * @throws CommandException If an error occurs during command execution.
      */
-    public abstract CommandResult execute(Model model, Storage storage) throws CommandException;
+    public abstract CommandResult execute(Model model, Storage storage, CommandHistory history) throws CommandException;
 
 }

--- a/src/main/java/seedu/resireg/logic/commands/CommandWordEnum.java
+++ b/src/main/java/seedu/resireg/logic/commands/CommandWordEnum.java
@@ -17,7 +17,8 @@ public enum CommandWordEnum {
     UNDO_COMMAND("undo"),
     ADD_ALIAS_COMMAND("alias"),
     DELETE_ALIAS_COMMAND("dealias"),
-    LIST_ALIAS_COMMAND("aliases");
+    LIST_ALIAS_COMMAND("aliases"),
+    HISTORY_COMMAND("history");
 
     private String commandWord;
 

--- a/src/main/java/seedu/resireg/logic/commands/DeallocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/DeallocateCommand.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import seedu.resireg.commons.core.Messages;
 import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.allocation.Allocation;
@@ -41,7 +42,7 @@ public class DeallocateCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws CommandException {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) throws CommandException {
         requireNonNull(model);
         List<Student> lastShownListStudent = model.getFilteredStudentList();
         List<Allocation> lastShownListAllocation = model.getFilteredAllocationList();

--- a/src/main/java/seedu/resireg/logic/commands/DeleteAliasCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/DeleteAliasCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.resireg.logic.parser.CliSyntax.PREFIX_ALIAS;
 import static seedu.resireg.logic.parser.CliSyntax.PREFIX_COMMAND;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.alias.CommandWordAlias;
@@ -36,7 +37,7 @@ public class DeleteAliasCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws CommandException {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) throws CommandException {
         requireNonNull(model);
 
         if (!model.hasCommandWordAlias(toDelete)) {

--- a/src/main/java/seedu/resireg/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/DeleteCommand.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import seedu.resireg.commons.core.Messages;
 import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.allocation.Allocation;
@@ -34,7 +35,7 @@ public class DeleteCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws CommandException {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) throws CommandException {
         requireNonNull(model);
         List<Student> lastShownList = model.getFilteredStudentList();
         List<Allocation> lastShownAllocationList = model.getFilteredAllocationList();

--- a/src/main/java/seedu/resireg/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/EditCommand.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import seedu.resireg.commons.core.Messages;
 import seedu.resireg.commons.core.index.Index;
 import seedu.resireg.commons.util.CollectionUtil;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.allocation.Allocation;
@@ -70,7 +71,7 @@ public class EditCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws CommandException {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) throws CommandException {
         requireNonNull(model);
         List<Student> lastShownList = model.getFilteredStudentList();
         List<Allocation> lastShownAllocationList = model.getFilteredAllocationList();

--- a/src/main/java/seedu/resireg/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ExitCommand.java
@@ -1,5 +1,6 @@
 package seedu.resireg.logic.commands;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.storage.Storage;
 
@@ -15,7 +16,7 @@ public class ExitCommand extends Command {
     public static final Help HELP = new Help(COMMAND_WORD, "Closes ResiReg.");
 
     @Override
-    public CommandResult execute(Model model, Storage storage) {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) {
         return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
     }
 

--- a/src/main/java/seedu/resireg/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/FindCommand.java
@@ -3,6 +3,7 @@ package seedu.resireg.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import seedu.resireg.commons.core.Messages;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.student.NameContainsKeywordsPredicate;
 import seedu.resireg.storage.Storage;
@@ -27,7 +28,7 @@ public class FindCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, Storage storage) {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) {
         requireNonNull(model);
         model.updateFilteredStudentList(predicate);
         return new CommandResult(

--- a/src/main/java/seedu/resireg/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/HelpCommand.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import seedu.resireg.commons.core.Messages;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.CommandMapper;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
@@ -52,7 +53,7 @@ public class HelpCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws CommandException {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) throws CommandException {
         if (input.isBlank()) {
             return new CommandResult(MESSAGE_GENERAL_HELP);
         } else if (commandWordToHelpMap.containsKey(input)) { // print full help message for specific command

--- a/src/main/java/seedu/resireg/logic/commands/HistoryCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/HistoryCommand.java
@@ -1,0 +1,39 @@
+package seedu.resireg.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import seedu.resireg.logic.CommandHistory;
+import seedu.resireg.model.Model;
+import seedu.resireg.storage.Storage;
+
+/**
+ * Lists all the commands entered by user from the start of app launch,
+ * in reverse chronological order.
+ */
+public class HistoryCommand extends Command {
+
+    public static final String COMMAND_WORD = "history";
+
+    public static final String MESSAGE_SUCCESS = "Entered commands: \n%1$s";
+    public static final String MESSAGE_NO_HISTORY = "No commands have been entered so far.";
+
+    public static final Help HELP =
+            new Help(COMMAND_WORD, "Shows all commands entered in reverse chronological order");
+
+    @Override
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) {
+        requireNonNull(history);
+        ArrayList<String> previousCommands = new ArrayList<>(history.getHistory());
+
+        if (previousCommands.size() == 0) {
+            return new CommandResult(MESSAGE_NO_HISTORY);
+        }
+
+        Collections.reverse(previousCommands);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, String.join("\n", previousCommands)));
+    }
+
+}

--- a/src/main/java/seedu/resireg/logic/commands/ListAliasCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ListAliasCommand.java
@@ -2,6 +2,7 @@ package seedu.resireg.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.storage.Storage;
 
@@ -19,7 +20,7 @@ public class ListAliasCommand extends Command {
     public static final Help HELP = new Help(COMMAND_WORD, "Lists all command-alias pairs.");
 
     @Override
-    public CommandResult execute(Model model, Storage storage) {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) {
         requireNonNull(model);
         if (model.getCommandWordAliases().isEmpty()) {
             return new CommandResult(MESSAGE_EMPTY_ALIAS);

--- a/src/main/java/seedu/resireg/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ListCommand.java
@@ -3,6 +3,7 @@ package seedu.resireg.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.resireg.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.storage.Storage;
 
@@ -18,7 +19,7 @@ public class ListCommand extends Command {
     public static final Help HELP = new Help(COMMAND_WORD, "Lists all students.");
 
     @Override
-    public CommandResult execute(Model model, Storage storage) {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) {
         requireNonNull(model);
         model.updateFilteredStudentList(PREDICATE_SHOW_ALL_PERSONS);
         return new ToggleCommandResult(MESSAGE_SUCCESS, TabView.STUDENTS);

--- a/src/main/java/seedu/resireg/logic/commands/ListRoomCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ListRoomCommand.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelPredicate;
 import seedu.resireg.model.room.Floor;
@@ -46,7 +47,7 @@ public class ListRoomCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, Storage storage) {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) {
         requireNonNull(model);
 
         model.updateFilteredRoomList(filter.getRoomPredicate());

--- a/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import seedu.resireg.commons.core.Messages;
 import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.allocation.Allocation;
@@ -50,7 +51,7 @@ public class ReallocateCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws CommandException {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) throws CommandException {
         requireNonNull(model);
         List<Student> lastShownListStudent = model.getFilteredStudentList();
         List<Room> lastShownListRoom = model.getFilteredRoomList();

--- a/src/main/java/seedu/resireg/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/RedoCommand.java
@@ -2,6 +2,7 @@ package seedu.resireg.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.storage.Storage;
@@ -19,7 +20,7 @@ public class RedoCommand extends Command {
     public static final Help HELP = new Help(COMMAND_WORD, "Redo a previous command.");
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws CommandException {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) throws CommandException {
         requireNonNull(model);
 
         if (!model.canRedoResiReg()) {

--- a/src/main/java/seedu/resireg/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/UndoCommand.java
@@ -2,6 +2,7 @@ package seedu.resireg.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.storage.Storage;
@@ -18,7 +19,7 @@ public class UndoCommand extends Command {
     public static final Help HELP = new Help(COMMAND_WORD, "Undo a previous command");
 
     @Override
-    public CommandResult execute(Model model, Storage storage) throws CommandException {
+    public CommandResult execute(Model model, Storage storage, CommandHistory history) throws CommandException {
         requireNonNull(model);
 
         if (!model.canUndoResiReg()) {

--- a/src/main/java/seedu/resireg/model/ReadOnlyResiReg.java
+++ b/src/main/java/seedu/resireg/model/ReadOnlyResiReg.java
@@ -1,5 +1,6 @@
 package seedu.resireg.model;
 
+import javafx.beans.Observable;
 import javafx.collections.ObservableList;
 import seedu.resireg.model.allocation.Allocation;
 import seedu.resireg.model.room.Room;
@@ -9,7 +10,7 @@ import seedu.resireg.model.student.Student;
 /**
  * Unmodifiable view of ResiReg
  */
-public interface ReadOnlyResiReg {
+public interface ReadOnlyResiReg extends Observable {
 
     /**
      * Returns the semester that this view is mapped to.

--- a/src/main/java/seedu/resireg/model/ResiReg.java
+++ b/src/main/java/seedu/resireg/model/ResiReg.java
@@ -6,7 +6,9 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 
+import javafx.beans.InvalidationListener;
 import javafx.collections.ObservableList;
+import seedu.resireg.commons.util.InvalidationListenerList;
 import seedu.resireg.model.allocation.Allocation;
 import seedu.resireg.model.allocation.UniqueAllocationList;
 import seedu.resireg.model.room.Room;
@@ -27,6 +29,7 @@ public class ResiReg implements ReadOnlyResiReg {
     private final UniqueStudentList students;
     private final UniqueRoomList rooms;
     private final UniqueAllocationList allocations;
+    private final InvalidationListenerList listenerList = new InvalidationListenerList();
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -61,6 +64,7 @@ public class ResiReg implements ReadOnlyResiReg {
      */
     public void setSemester(Semester semester) {
         this.semester = semester;
+        indicateModified();
     }
 
     public static ResiReg getNextSemesterResiReg(ReadOnlyResiReg toBeCopied) {
@@ -89,6 +93,7 @@ public class ResiReg implements ReadOnlyResiReg {
      */
     public void setStudents(List<Student> students) {
         this.students.setStudents(students);
+        indicateModified();
     }
 
     /**
@@ -97,6 +102,7 @@ public class ResiReg implements ReadOnlyResiReg {
      */
     public void setRooms(List<Room> rooms) {
         this.rooms.setRooms(rooms);
+        indicateModified();
     }
 
     /**
@@ -105,6 +111,7 @@ public class ResiReg implements ReadOnlyResiReg {
      */
     public void setAllocations(List<Allocation> allocations) {
         this.allocations.setAllocations(allocations);
+        indicateModified();
     }
 
     /**
@@ -135,6 +142,7 @@ public class ResiReg implements ReadOnlyResiReg {
      */
     public void addStudent(Student p) {
         students.add(p);
+        indicateModified();
     }
 
     /**
@@ -146,6 +154,7 @@ public class ResiReg implements ReadOnlyResiReg {
     public void setStudent(Student target, Student editedStudent) {
         requireNonNull(editedStudent);
         students.setStudent(target, editedStudent);
+        indicateModified();
     }
 
     /**
@@ -154,6 +163,7 @@ public class ResiReg implements ReadOnlyResiReg {
      */
     public void removeStudent(Student key) {
         students.remove(key);
+        indicateModified();
     }
 
     /**
@@ -181,6 +191,7 @@ public class ResiReg implements ReadOnlyResiReg {
      */
     public void addRoom(Room r) {
         rooms.add(r);
+        indicateModified();
     }
 
     /**
@@ -200,6 +211,7 @@ public class ResiReg implements ReadOnlyResiReg {
     public void setRoom(Room target, Room editedRoom) {
         requireNonNull(editedRoom);
         rooms.setRoom(target, editedRoom);
+        indicateModified();
     }
 
     /**
@@ -208,6 +220,7 @@ public class ResiReg implements ReadOnlyResiReg {
      */
     public void removeRoom(Room key) {
         rooms.remove(key);
+        indicateModified();
     }
 
     //// allocation-level operations
@@ -219,6 +232,7 @@ public class ResiReg implements ReadOnlyResiReg {
     public void addAllocation(Allocation allocation) {
         requireNonNull(allocation);
         allocations.add(allocation);
+        indicateModified();
     }
 
     /**
@@ -238,6 +252,7 @@ public class ResiReg implements ReadOnlyResiReg {
     public void setAllocation(Allocation target, Allocation editedAllocation) {
         requireNonNull(editedAllocation);
         allocations.setAllocation(target, editedAllocation);
+        indicateModified();
     }
 
     /**
@@ -246,6 +261,23 @@ public class ResiReg implements ReadOnlyResiReg {
      */
     public void removeAllocation(Allocation key) {
         allocations.remove(key);
+        indicateModified();
+    }
+
+    //// methods related to listeners
+    public void addListener(InvalidationListener listener) {
+        listenerList.addListener(listener);
+    }
+
+    public void removeListener(InvalidationListener listener) {
+        listenerList.removeListener(listener);
+    }
+
+    /**
+     * Notifies listeners that there are modifications to resireg.
+     */
+    protected void indicateModified() {
+        listenerList.callListeners(this);
     }
 
     //// util methods

--- a/src/main/java/seedu/resireg/ui/ListPtr.java
+++ b/src/main/java/seedu/resireg/ui/ListPtr.java
@@ -1,0 +1,109 @@
+package seedu.resireg.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Has a pointer that points to an element in the list, and is able to iterate through the list.
+ */
+public class ListPtr {
+    private List<String> list;
+    private int index;
+
+    /**
+     * Constructs a {@code ListElementPtr} object using a list.
+     * The pointer points to the last element in the {@code list}.
+     */
+    public ListPtr(List<String> list) {
+        this.list = new ArrayList<>(list);
+        index = this.list.size() - 1;
+    }
+
+    /**
+     * Appends {@code item} to the end of the list.
+     */
+    public void add(String item) {
+        list.add(item);
+    }
+
+    /**
+     * Returns true if calling {@code #next()} does not throw a {@code NoSuchElementException}.
+     */
+    public boolean hasNext() {
+        int next = index + 1;
+        return isWithinBounds(next);
+    }
+
+    /**
+     * Returns true if calling {@code #previous()} does not throw a {@code NoSuchElementException}.
+     */
+    public boolean hasPrevious() {
+        int prev = index - 1;
+        return isWithinBounds(prev);
+    }
+
+    /**
+     * Returns true if calling {@code #current()} does not throw a {@code NoSuchElementException}.
+     */
+    public boolean hasCurrent() {
+        return isWithinBounds(index);
+    }
+
+    private boolean isWithinBounds(int index) {
+        return index >= 0 && index < list.size();
+    }
+
+    /**
+     * Shifts the pointer position rightwards and returns the next element in the list.
+     * @throws NoSuchElementException if there is no more next element.
+     */
+    public String next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        index++;
+        return list.get(index);
+    }
+
+    /**
+     * Shifts the pointer position leftwards and returns the previous element in the list.
+     * @throws NoSuchElementException if there is no more previous element.
+     */
+    public String previous() {
+        if (!hasPrevious()) {
+            throw new NoSuchElementException();
+        }
+        index--;
+        return list.get(index);
+    }
+
+    /**
+     * Returns the current element in the list.
+     * @throws NoSuchElementException if the list is empty.
+     */
+    public String current() {
+        if (!hasCurrent()) {
+            throw new NoSuchElementException();
+        }
+        return list.get(index);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ListPtr)) {
+            return false;
+        }
+
+        // state check
+        ListPtr o = (ListPtr) other;
+        return list.equals(o.list) && index == o.index;
+    }
+}
+

--- a/src/main/java/seedu/resireg/ui/MainWindow.java
+++ b/src/main/java/seedu/resireg/ui/MainWindow.java
@@ -141,7 +141,7 @@ public class MainWindow extends UiPart<Stage> {
         SemesterDisplay semesterDisplay = new SemesterDisplay(logic.getSemester());
         semesterDisplayPlaceholder.getChildren().add(semesterDisplay.getRoot());
 
-        CommandBox commandBox = new CommandBox(this::executeCommand);
+        CommandBox commandBox = new CommandBox(this::executeCommand, logic.getHistory());
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
         commandBox.requestFocus(); // so the user can start entering commands right away
     }

--- a/src/test/java/seedu/resireg/commons/util/InvalidationListenerListTest.java
+++ b/src/test/java/seedu/resireg/commons/util/InvalidationListenerListTest.java
@@ -1,0 +1,83 @@
+package seedu.resireg.commons.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.beans.InvalidationListener;
+import javafx.beans.property.SimpleObjectProperty;
+
+public class InvalidationListenerListTest {
+    private final SimpleObjectProperty<Object> testObservable = new SimpleObjectProperty<>();
+    private final InvalidationListenerList listenerList = new InvalidationListenerList();
+    private String state = "";
+
+    @Test
+    public void addListener_sameListenerOnce_listenerAdded() {
+        listenerList.addListener(observable -> {
+            state += "a";
+            assertEquals(testObservable, observable);
+        });
+        listenerList.callListeners(testObservable);
+        assertEquals("a", state);
+    }
+
+    @Test
+    public void addListener_sameListenerTwice_listenerAddedTwice() {
+        InvalidationListener listener = observable -> state += "a";
+        listenerList.addListener(listener);
+        listenerList.addListener(listener);
+        listenerList.callListeners(testObservable);
+        assertEquals("aa", state);
+    }
+
+    @Test
+    public void addListener_listenersBeingCalled_listenerNotCalled() {
+        InvalidationListener listener = observable -> {
+            throw new AssertionError("This method should not be called");
+        };
+        InvalidationListener otherListener = observable -> listenerList.addListener(listener);
+        listenerList.addListener(otherListener);
+        listenerList.callListeners(testObservable);
+    }
+
+    @Test
+    public void removeListener_singleListenerAdded_listenerRemoved() {
+        InvalidationListener listener = observable -> state += "a";
+        listenerList.addListener(listener);
+        listenerList.removeListener(listener);
+        listenerList.callListeners(testObservable);
+        assertEquals("", state);
+    }
+
+    @Test
+    public void removeListener_sameListenerAddedTwice_firstListenerRemoved() {
+        InvalidationListener listener = observable -> state += "a";
+        listenerList.addListener(listener);
+        listenerList.addListener(listener);
+        listenerList.removeListener(listener);
+        listenerList.callListeners(testObservable);
+        assertEquals("a", state);
+    }
+
+    @Test
+    public void removeListener_sameListenerAddedTwice_bothListenersRemoved() {
+        InvalidationListener listener = observable -> state += "a";
+        listenerList.addListener(listener);
+        listenerList.addListener(listener);
+        listenerList.removeListener(listener);
+        listenerList.removeListener(listener);
+        listenerList.callListeners(testObservable);
+        assertEquals("", state);
+    }
+
+    @Test
+    public void removeListener_listenersBeingCalled_listenerStillCalled() {
+        InvalidationListener listener = observable -> state += "a";
+        InvalidationListener otherListener = observable -> listenerList.removeListener(listener);
+        listenerList.addListener(otherListener);
+        listenerList.addListener(listener);
+        listenerList.callListeners(testObservable);
+        assertEquals("a", state);
+    }
+}

--- a/src/test/java/seedu/resireg/logic/CommandHistoryTest.java
+++ b/src/test/java/seedu/resireg/logic/CommandHistoryTest.java
@@ -1,0 +1,88 @@
+package seedu.resireg.logic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CommandHistoryTest {
+    private CommandHistory history;
+
+    @BeforeEach
+    public void setUp() {
+        history = new CommandHistory();
+    }
+
+    @Test
+    public void constructor_withCommandHistory_copiesCommandHistory() {
+        final CommandHistory historyWithC = new CommandHistory();
+        historyWithC.add("c");
+
+        assertEquals(historyWithC, new CommandHistory(historyWithC));
+    }
+
+    @Test
+    public void add() {
+        final String validCommand = "rooms";
+        final String invalidCommand = "something";
+
+        history.add(validCommand);
+        history.add(invalidCommand);
+        assertEquals(Arrays.asList(validCommand, invalidCommand), history.getHistory());
+    }
+
+    @Test
+    void getHistory() {
+        final CommandHistory historyWithCD = new CommandHistory();
+        historyWithCD.add("c");
+        historyWithCD.add("d");
+
+        assertEquals(Arrays.asList("c", "d"), historyWithCD.getHistory());
+    }
+
+    @Test
+    void equals() {
+        final CommandHistory historyWithC = new CommandHistory();
+        historyWithC.add("c");
+        final CommandHistory anotherHistoryWithC = new CommandHistory();
+        anotherHistoryWithC.add("c");
+        final CommandHistory historyWithD = new CommandHistory();
+        historyWithD.add("d");
+
+        // same object -> returns true
+        assertTrue(historyWithC.equals(historyWithC));
+
+        // same values -> returns true
+        assertTrue(historyWithC.equals(anotherHistoryWithC));
+
+        // null -> returns false
+        assertFalse(historyWithD.equals(null));
+
+        // different types -> returns false
+        assertFalse(historyWithD.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(historyWithD.equals(historyWithC));
+    }
+
+    @Test
+    void hashcode() {
+        final CommandHistory historyWithC = new CommandHistory();
+        historyWithC.add("c");
+        final CommandHistory anotherHistoryWithC = new CommandHistory();
+        anotherHistoryWithC.add("c");
+        final CommandHistory historyWithD = new CommandHistory();
+        historyWithD.add("d");
+
+        // same values -> returns same hashcode
+        assertEquals(historyWithC.hashCode(), anotherHistoryWithC.hashCode());
+
+        // different values -> returns different hashcode
+        assertNotEquals(historyWithC.hashCode(), historyWithD.hashCode());
+    }
+}

--- a/src/test/java/seedu/resireg/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/resireg/logic/LogicManagerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import seedu.resireg.logic.commands.AddCommand;
 import seedu.resireg.logic.commands.CommandResult;
+import seedu.resireg.logic.commands.HistoryCommand;
 import seedu.resireg.logic.commands.ListCommand;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.logic.parser.exceptions.ParseException;
@@ -55,18 +56,21 @@ public class LogicManagerTest {
     public void execute_invalidCommandFormat_throwsParseException() {
         String invalidCommand = "uicfhmowqewca";
         assertParseException(invalidCommand, MESSAGE_UNKNOWN_COMMAND);
+        assertHistoryCorrect(invalidCommand);
     }
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
         String deleteCommand = "delete 9";
         assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertHistoryCorrect(deleteCommand);
     }
 
     @Test
     public void execute_validCommand_success() throws Exception {
         String listCommand = ListCommand.COMMAND_WORD;
         assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+        assertHistoryCorrect(listCommand);
     }
 
     @Test
@@ -88,6 +92,7 @@ public class LogicManagerTest {
         expectedModel.saveStateResiReg();
         String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);
+        assertHistoryCorrect(addCommand);
     }
 
     @Test
@@ -146,6 +151,22 @@ public class LogicManagerTest {
             String expectedMessage, Model expectedModel) {
         assertThrows(expectedException, expectedMessage, () -> logic.execute(inputCommand));
         assertEquals(expectedModel, model);
+    }
+
+    /**
+     * Asserts that the result display shows all the {@expectedCommands}
+     * upon the execution of {@code HistoryCommand}
+     */
+    private void assertHistoryCorrect(String ...expectedCommands) {
+        try {
+            CommandResult result = logic.execute(HistoryCommand.COMMAND_WORD);
+            String expectedMessage = String.format(
+                    HistoryCommand.MESSAGE_SUCCESS, String.join("\n",
+                            expectedCommands));
+            assertEquals(expectedMessage, result.getFeedbackToUser());
+        } catch (ParseException | CommandException e) {
+            throw new AssertionError("Parsing and execution of HistoryCommand.COMMAND_WORD should succeed.", e);
+        }
     }
 
     /**

--- a/src/test/java/seedu/resireg/logic/commands/AddAliasCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/AddAliasCommandTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import seedu.resireg.commons.core.GuiSettings;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelPredicate;
@@ -32,6 +33,8 @@ import seedu.resireg.testutil.CommandWordAliasBuilder;
 
 public class AddAliasCommandTest {
 
+    private CommandHistory history = new CommandHistory();
+
     @Test
     public void constructor_nullAlias_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new AddAliasCommand(null));
@@ -43,7 +46,7 @@ public class AddAliasCommandTest {
         CommandWordAlias validAlias = new CommandWordAliasBuilder().build();
         Storage storageStub = null;
 
-        CommandResult commandResult = new AddAliasCommand(validAlias).execute(modelStub, storageStub);
+        CommandResult commandResult = new AddAliasCommand(validAlias).execute(modelStub, storageStub, history);
 
         assertEquals(String.format(AddAliasCommand.MESSAGE_SUCCESS, validAlias), commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validAlias), modelStub.aliasesAdded);
@@ -57,7 +60,7 @@ public class AddAliasCommandTest {
         Storage storageStub = null;
 
         assertThrows(CommandException.class,
-            AddAliasCommand.MESSAGE_DUPLICATE_ALIAS, () -> addAliasCommand.execute(modelStub, storageStub));
+            AddAliasCommand.MESSAGE_DUPLICATE_ALIAS, () -> addAliasCommand.execute(modelStub, storageStub, history));
     }
 
     @Test

--- a/src/test/java/seedu/resireg/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/AddCommandIntegrationTest.java
@@ -7,6 +7,7 @@ import static seedu.resireg.testutil.TypicalStudents.getTypicalResiReg;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
 import seedu.resireg.model.UserPrefs;
@@ -17,6 +18,8 @@ import seedu.resireg.testutil.StudentBuilder;
  * Contains integration tests (interaction with the Model) for {@code AddCommand}.
  */
 public class AddCommandIntegrationTest {
+
+    private CommandHistory history = new CommandHistory();
 
     private Model model;
 
@@ -33,7 +36,7 @@ public class AddCommandIntegrationTest {
         expectedModel.addStudent(validStudent);
         expectedModel.saveStateResiReg();
 
-        assertCommandSuccess(new AddCommand(validStudent), model,
+        assertCommandSuccess(new AddCommand(validStudent), model, history,
                 String.format(AddCommand.MESSAGE_SUCCESS, validStudent.getName().fullName,
                     validStudent.getStudentId().value), expectedModel);
     }
@@ -41,7 +44,7 @@ public class AddCommandIntegrationTest {
     @Test
     public void execute_duplicateStudent_throwsCommandException() {
         Student studentInList = model.getResiReg().getStudentList().get(0);
-        assertCommandFailure(new AddCommand(studentInList), model, AddCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(new AddCommand(studentInList), model, history, AddCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
 }

--- a/src/test/java/seedu/resireg/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/AddCommandTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.ObservableList;
 import seedu.resireg.commons.core.GuiSettings;
 import seedu.resireg.commons.exceptions.DataConversionException;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelPredicate;
@@ -36,6 +37,8 @@ import seedu.resireg.testutil.StudentBuilder;
 
 public class AddCommandTest {
 
+    private CommandHistory history = new CommandHistory();
+
     @Test
     public void constructor_nullStudent_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new AddCommand(null));
@@ -47,7 +50,7 @@ public class AddCommandTest {
         StorageStub storageStub = new StorageStub();
         Student validStudent = new StudentBuilder().build();
 
-        CommandResult commandResult = new AddCommand(validStudent).execute(modelStub, storageStub);
+        CommandResult commandResult = new AddCommand(validStudent).execute(modelStub, storageStub, history);
 
         assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, validStudent.getName().fullName,
             validStudent.getStudentId().value), commandResult.getFeedbackToUser());
@@ -62,7 +65,7 @@ public class AddCommandTest {
         StorageStub storageStub = new StorageStub();
 
         assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () ->
-            addCommand.execute(modelStub, storageStub));
+            addCommand.execute(modelStub, storageStub, history));
     }
 
     @Test

--- a/src/test/java/seedu/resireg/logic/commands/AllocateCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/AllocateCommandTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.resireg.commons.core.Messages;
 import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
 import seedu.resireg.model.UserPrefs;
@@ -33,6 +34,8 @@ import seedu.resireg.model.student.Student;
  * is free to be allocated.
  */
 public class AllocateCommandTest {
+
+    private CommandHistory history = new CommandHistory();
 
     private Model model = new ModelManager(getTypicalResiReg(), new UserPrefs());
 
@@ -51,21 +54,21 @@ public class AllocateCommandTest {
         expectedModel.addAllocation(toAllocate);
         expectedModel.saveStateResiReg();
 
-        assertCommandSuccess(allocateCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(allocateCommand, model, history, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_invalidIndexStudentUnfilteredList_throwsCommandException() {
         Index outOfBoundIndexStudent = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
         AllocateCommand allocateCommand = new AllocateCommand(outOfBoundIndexStudent, INDEX_FOURTH_ROOM);
-        assertCommandFailure(allocateCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(allocateCommand, model, history, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void execute_invalidIndexRoomUnfilteredList_throwsCommandException() {
         Index outOfBoundIndexRoom = Index.fromOneBased(model.getFilteredRoomList().size() + 1);
         AllocateCommand allocateCommand = new AllocateCommand(INDEX_FOURTH_ROOM, outOfBoundIndexRoom);
-        assertCommandFailure(allocateCommand, model, Messages.MESSAGE_INVALID_ROOM_DISPLAYED_INDEX);
+        assertCommandFailure(allocateCommand, model, history, Messages.MESSAGE_INVALID_ROOM_DISPLAYED_INDEX);
     }
 
     @Test
@@ -75,7 +78,7 @@ public class AllocateCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getResiReg().getStudentList().size());
         AllocateCommand allocateCommand = new AllocateCommand(outOfBoundIndex, INDEX_FIRST_ROOM);
-        assertCommandFailure(allocateCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(allocateCommand, model, history, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
@@ -85,7 +88,7 @@ public class AllocateCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getResiReg().getRoomList().size());
         AllocateCommand allocateCommand = new AllocateCommand(INDEX_FIRST_PERSON, outOfBoundIndex);
-        assertCommandFailure(allocateCommand, model, Messages.MESSAGE_INVALID_ROOM_DISPLAYED_INDEX);
+        assertCommandFailure(allocateCommand, model, history, Messages.MESSAGE_INVALID_ROOM_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/resireg/logic/commands/ArchiveCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/ArchiveCommandTest.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import seedu.resireg.commons.exceptions.DataConversionException;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
@@ -20,6 +21,8 @@ import seedu.resireg.storage.Storage;
 
 class ArchiveCommandTest {
 
+    private CommandHistory history = new CommandHistory();
+
     @Test
     public void execute_archivalSuccessResiReg_success() {
         Model model = new ModelManager();
@@ -28,7 +31,7 @@ class ArchiveCommandTest {
 
         PassingStorageStub storageStub = new PassingStorageStub();
         try {
-            CommandResult result = new ArchiveCommand().execute(model, storageStub);
+            CommandResult result = new ArchiveCommand().execute(model, storageStub, history);
             assertEquals(new CommandResult(ArchiveCommand.MESSAGE_SUCCESS), result);
             assertEquals(expectedModel, model);
         } catch (CommandException ce) {
@@ -43,7 +46,7 @@ class ArchiveCommandTest {
         expectedModel.saveStateResiReg();
 
         FailingStorageStub storageStub = new FailingStorageStub();
-        assertThrows(CommandException.class, () -> new ArchiveCommand().execute(model, storageStub));
+        assertThrows(CommandException.class, () -> new ArchiveCommand().execute(model, storageStub, history));
     }
 
     /**

--- a/src/test/java/seedu/resireg/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/ClearCommandTest.java
@@ -5,6 +5,7 @@ import static seedu.resireg.testutil.TypicalStudents.getTypicalResiReg;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
 import seedu.resireg.model.ResiReg;
@@ -12,13 +13,15 @@ import seedu.resireg.model.UserPrefs;
 
 public class ClearCommandTest {
 
+    private CommandHistory history = new CommandHistory();
+
     @Test
     public void execute_emptyResiReg_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
         expectedModel.saveStateResiReg();
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ClearCommand(), model, history, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
@@ -28,7 +31,7 @@ public class ClearCommandTest {
         expectedModel.setResiReg(new ResiReg());
         expectedModel.saveStateResiReg();
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ClearCommand(), model, history, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
 }

--- a/src/test/java/seedu/resireg/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/resireg/logic/commands/CommandTestUtil.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import seedu.resireg.commons.core.index.Index;
 import seedu.resireg.commons.exceptions.DataConversionException;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.exceptions.CommandException;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ReadOnlyResiReg;
@@ -126,12 +127,14 @@ public class CommandTestUtil {
      * Executes the given {@code command}, confirms that <br>
      * - the returned {@link CommandResult} matches {@code expectedCommandResult} <br>
      * - the {@code actualModel} matches {@code expectedModel}
+     * - the {@code actualHistory} remains unchanged
      */
-    public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
+    public static void assertCommandSuccess(Command command, Model actualModel, CommandHistory actualHistory,
+                                            CommandResult expectedCommandResult,
                                             Model expectedModel) {
         StorageStub storageStub = new StorageStub();
         try {
-            CommandResult result = command.execute(actualModel, storageStub);
+            CommandResult result = command.execute(actualModel, storageStub, actualHistory);
             assertEquals(expectedCommandResult, result);
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {
@@ -140,13 +143,14 @@ public class CommandTestUtil {
     }
 
     /**
-     * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandResult, Model)}
+     * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandHistory, CommandResult, Model)}
      * that takes a string {@code expectedMessage}.
      */
-    public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
+    public static void assertCommandSuccess(Command command, Model actualModel, CommandHistory actualHistory,
+                                            String expectedMessage,
                                             Model expectedModel) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage);
-        assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
+        assertCommandSuccess(command, actualModel, actualHistory, expectedCommandResult, expectedModel);
     }
 
     /**
@@ -154,10 +158,11 @@ public class CommandTestUtil {
      * - the returned {@link ToggleCommandResult} matches {@code expectedCommandResult} <br>
      * - the {@code actualModel} matches {@code expectedModel}
      */
-    public static void assertToggleCommandSuccess(Command command, Model actualModel, String expectedMessage,
+    public static void assertToggleCommandSuccess(Command command, Model actualModel, CommandHistory actualHistory,
+                                                  String expectedMessage,
                                                   Model expectedModel, TabView tabView) {
         ToggleCommandResult expectedCommandResult = new ToggleCommandResult(expectedMessage, tabView);
-        assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
+        assertCommandSuccess(command, actualModel, actualHistory, expectedCommandResult, expectedModel);
     }
 
     /**
@@ -165,15 +170,18 @@ public class CommandTestUtil {
      * - a {@code CommandException} is thrown <br>
      * - the CommandException message matches {@code expectedMessage} <br>
      * - the rest of the model, filtered student list and selected student in {@code actualModel} remain unchanged
+     * - {@code actualHistory} remains unchanged.
      */
-    public static void assertCommandFailure(Command command, Model actualModel, String expectedMessage) {
+    public static void assertCommandFailure(Command command, Model actualModel, CommandHistory actualHistory,
+                                            String expectedMessage) {
         // we are unable to defensively copy the model for comparison later, so we can
         // only do so by copying its components.
         ResiReg expectedResiReg = new ResiReg(actualModel.getResiReg());
         List<Student> expectedFilteredList = new ArrayList<>(actualModel.getFilteredStudentList());
         StorageStub storageStub = new StorageStub();
 
-        assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel, storageStub));
+        assertThrows(CommandException.class, expectedMessage, () ->
+                command.execute(actualModel, storageStub, actualHistory));
         assertEquals(expectedResiReg, actualModel.getResiReg());
         assertEquals(expectedFilteredList, actualModel.getFilteredStudentList());
     }

--- a/src/test/java/seedu/resireg/logic/commands/DeallocateCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/DeallocateCommandTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.resireg.commons.core.Messages;
 import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
 import seedu.resireg.model.UserPrefs;
@@ -30,6 +31,8 @@ import seedu.resireg.model.student.Student;
  * is free to be allocated.
  */
 public class DeallocateCommandTest {
+
+    private CommandHistory history = new CommandHistory();
 
     private Model model = new ModelManager(getTypicalResiReg(), new UserPrefs());
 
@@ -55,14 +58,14 @@ public class DeallocateCommandTest {
         expectedModel.removeAllocation(toDeallocate);
         expectedModel.saveStateResiReg();
 
-        assertCommandSuccess(deallocateCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deallocateCommand, model, history, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_invalidIndexStudentUnfilteredList_throwsCommandException() {
         Index outOfBoundIndexStudent = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
         DeallocateCommand deallocateCommand = new DeallocateCommand(outOfBoundIndexStudent);
-        assertCommandFailure(deallocateCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deallocateCommand, model, history, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
@@ -72,7 +75,7 @@ public class DeallocateCommandTest {
         // ensures that outOfBoundIndex is still in bounds of ResiReg list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getResiReg().getStudentList().size());
         DeallocateCommand deallocateCommand = new DeallocateCommand(outOfBoundIndex);
-        assertCommandFailure(deallocateCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deallocateCommand, model, history, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/resireg/logic/commands/DeleteAliasCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/DeleteAliasCommandTest.java
@@ -13,6 +13,7 @@ import static seedu.resireg.testutil.TypicalStudents.getTypicalResiReg;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
 import seedu.resireg.model.alias.CommandWordAlias;
@@ -22,6 +23,8 @@ import seedu.resireg.model.alias.CommandWordAlias;
  * {@code DeleteCommand}.
  */
 public class DeleteAliasCommandTest {
+
+    private CommandHistory history = new CommandHistory();
 
     private Model model = new ModelManager(getTypicalResiReg(), getTypicalUserPrefs());
 
@@ -36,7 +39,7 @@ public class DeleteAliasCommandTest {
         expectedModel.deleteCommandWordAlias(aliasToDelete);
 
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteCommand, model, history, expectedMessage, expectedModel);
     }
 
     @Test
@@ -44,7 +47,7 @@ public class DeleteAliasCommandTest {
         CommandWordAlias outOfBoundAlias = ROOMS_RO;
         DeleteAliasCommand deleteCommand = new DeleteAliasCommand(ROOMS_RO);
 
-        assertCommandFailure(deleteCommand, model, DeleteAliasCommand.MESSAGE_INVALID_ALIAS);
+        assertCommandFailure(deleteCommand, model, history, DeleteAliasCommand.MESSAGE_INVALID_ALIAS);
     }
 
     @Test

--- a/src/test/java/seedu/resireg/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/DeleteCommandTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.resireg.commons.core.Messages;
 import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
 import seedu.resireg.model.UserPrefs;
@@ -25,6 +26,8 @@ import seedu.resireg.storage.Storage;
  * {@code DeleteCommand}.
  */
 public class DeleteCommandTest {
+
+    private CommandHistory history = new CommandHistory();
 
     private Model model = new ModelManager(getTypicalResiReg(), new UserPrefs());
     private Storage storage = null;
@@ -40,7 +43,7 @@ public class DeleteCommandTest {
         expectedModel.deleteStudent(studentToDelete);
         expectedModel.saveStateResiReg();
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteCommand, model, history, expectedMessage, expectedModel);
     }
 
     @Test
@@ -48,7 +51,7 @@ public class DeleteCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, history, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
@@ -65,7 +68,7 @@ public class DeleteCommandTest {
         expectedModel.saveStateResiReg();
         showNoStudent(expectedModel);
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deleteCommand, model, history, expectedMessage, expectedModel);
     }
 
     @Test
@@ -78,7 +81,7 @@ public class DeleteCommandTest {
 
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, history, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
@@ -90,15 +93,15 @@ public class DeleteCommandTest {
         expectedModel.saveStateResiReg();
 
         // delete -> first student deleted
-        deleteCommand.execute(model, storage);
+        deleteCommand.execute(model, storage, history);
 
         // undo -> reverts resireg back to previous state
         expectedModel.undoResiReg();
-        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new UndoCommand(), model, history, UndoCommand.MESSAGE_SUCCESS, expectedModel);
 
         // redo -> same first student deleted again
         expectedModel.redoResiReg();
-        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new RedoCommand(), model, history, RedoCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
@@ -107,11 +110,11 @@ public class DeleteCommandTest {
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
         // execution failed -> state not added to model
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, history, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         // single resireg state in model -> undo and redo failures
-        assertCommandFailure(new UndoCommand(), model, UndoCommand.MESSAGE_FAILURE);
-        assertCommandFailure(new RedoCommand(), model, RedoCommand.MESSAGE_FAILURE);
+        assertCommandFailure(new UndoCommand(), model, history, UndoCommand.MESSAGE_FAILURE);
+        assertCommandFailure(new RedoCommand(), model, history, RedoCommand.MESSAGE_FAILURE);
     }
 
     /**
@@ -133,12 +136,12 @@ public class DeleteCommandTest {
         expectedModel.saveStateResiReg();
 
         // delete -> deletes second student in unfiltered student list, first student in filtered student list
-        deleteCommand.execute(model, storage);
+        deleteCommand.execute(model, storage, history);
 
         // undo -> reverts resireg back to previous state, keeps filtering
         expectedModel.undoResiReg();
         showStudentAtIndex(expectedModel, INDEX_SECOND_PERSON);
-        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new UndoCommand(), model, history, UndoCommand.MESSAGE_SUCCESS, expectedModel);
 
         // remove filtering
         model.updateFilteredStudentList(Model.PREDICATE_SHOW_ALL_PERSONS);
@@ -147,7 +150,7 @@ public class DeleteCommandTest {
         assertNotEquals(toDelete, model.getFilteredStudentList().get(INDEX_FIRST_PERSON.getZeroBased()));
         // redo -> delete same second student in unfiltered student list
         expectedModel.redoResiReg();
-        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new RedoCommand(), model, history, RedoCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/resireg/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/EditCommandTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.resireg.commons.core.Messages;
 import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.EditCommand.EditStudentDescriptor;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
@@ -35,6 +36,8 @@ import seedu.resireg.testutil.StudentBuilder;
  */
 public class EditCommandTest {
 
+    private CommandHistory history = new CommandHistory();
+
     private Model model = new ModelManager(getTypicalResiReg(), new UserPrefs());
     private Storage storage = new StorageManager(null, null);
 
@@ -50,7 +53,7 @@ public class EditCommandTest {
         expectedModel.setStudent(model.getFilteredStudentList().get(0), editedStudent);
         expectedModel.saveStateResiReg();
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editCommand, model, history, expectedMessage, expectedModel);
     }
 
     @Test
@@ -72,7 +75,7 @@ public class EditCommandTest {
         expectedModel.setStudent(lastStudent, editedStudent);
         expectedModel.saveStateResiReg();
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editCommand, model, history, expectedMessage, expectedModel);
     }
 
     @Test
@@ -85,7 +88,7 @@ public class EditCommandTest {
         Model expectedModel = new ModelManager(new ResiReg(model.getResiReg()), new UserPrefs());
         expectedModel.saveStateResiReg();
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editCommand, model, history, expectedMessage, expectedModel);
     }
 
     @Test
@@ -104,7 +107,7 @@ public class EditCommandTest {
         expectedModel.setStudent(model.getFilteredStudentList().get(0), editedStudent);
         expectedModel.saveStateResiReg();
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editCommand, model, history, expectedMessage, expectedModel);
     }
 
     @Test
@@ -113,7 +116,7 @@ public class EditCommandTest {
         EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder(firstStudent).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, history, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
@@ -125,7 +128,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
             new EditStudentDescriptorBuilder(studentInList).build());
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, history, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
@@ -134,7 +137,7 @@ public class EditCommandTest {
         EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, history, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     /**
@@ -151,7 +154,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
             new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, history, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
@@ -165,15 +168,15 @@ public class EditCommandTest {
         expectedModel.saveStateResiReg();
 
         // edit -> first student edited
-        editCommand.execute(model, storage);
+        editCommand.execute(model, storage, history);
 
         // undo -> reverts resireg back to prev state and filtered student list to show all students
         expectedModel.undoResiReg();
-        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new UndoCommand(), model, history, UndoCommand.MESSAGE_SUCCESS, expectedModel);
 
         // redo -> same first student edited again
         expectedModel.redoResiReg();
-        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new RedoCommand(), model, history, RedoCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
@@ -183,11 +186,11 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(outofBounds, desc);
 
         // execution failed -> resireg state not added into model
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, history, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         // single resireg state in mode -> undo and redo fails
-        assertCommandFailure(new UndoCommand(), model, UndoCommand.MESSAGE_FAILURE);
-        assertCommandFailure(new RedoCommand(), model, RedoCommand.MESSAGE_FAILURE);
+        assertCommandFailure(new UndoCommand(), model, history, UndoCommand.MESSAGE_FAILURE);
+        assertCommandFailure(new RedoCommand(), model, history, RedoCommand.MESSAGE_FAILURE);
     }
 
     /**
@@ -211,12 +214,12 @@ public class EditCommandTest {
         expectedModel.saveStateResiReg();
 
         // edit -> edits second student in unfiltered list / first student in filtered student list
-        editCommand.execute(model, storage);
+        editCommand.execute(model, storage, history);
 
         // undo -> reverts resireg back to prev state, keeps filtering
         expectedModel.undoResiReg();
         showStudentAtIndex(expectedModel, INDEX_SECOND_PERSON);
-        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new UndoCommand(), model, history, UndoCommand.MESSAGE_SUCCESS, expectedModel);
 
         // remove filtering
         model.updateFilteredStudentList(Model.PREDICATE_SHOW_ALL_PERSONS);
@@ -225,7 +228,7 @@ public class EditCommandTest {
         assertNotEquals(model.getFilteredStudentList().get(INDEX_FIRST_PERSON.getZeroBased()), studentToEdit);
         // redo -> edits same second student in unfiltered student list
         expectedModel.redoResiReg();
-        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new RedoCommand(), model, history, RedoCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/resireg/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/ExitCommandTest.java
@@ -5,16 +5,19 @@ import static seedu.resireg.logic.commands.ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEM
 
 import org.junit.jupiter.api.Test;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
 
 public class ExitCommandTest {
+    private CommandHistory history = new CommandHistory();
+
     private Model model = new ModelManager();
     private Model expectedModel = new ModelManager();
 
     @Test
     public void execute_exit_success() {
         CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
-        assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
+        assertCommandSuccess(new ExitCommand(), model, history, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/resireg/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/FindCommandTest.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
 import seedu.resireg.model.UserPrefs;
@@ -24,6 +25,8 @@ import seedu.resireg.model.student.NameContainsKeywordsPredicate;
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class FindCommandTest {
+    private CommandHistory history = new CommandHistory();
+
     private Model model = new ModelManager(getTypicalResiReg(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalResiReg(), new UserPrefs());
 
@@ -60,7 +63,7 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredStudentList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertCommandSuccess(command, model, history, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredStudentList());
     }
 
@@ -70,7 +73,7 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredStudentList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertCommandSuccess(command, model, history, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredStudentList());
     }
 

--- a/src/test/java/seedu/resireg/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/HelpCommandTest.java
@@ -5,40 +5,44 @@ import static seedu.resireg.logic.commands.CommandTestUtil.assertCommandSuccess;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
 
 public class HelpCommandTest {
+    private CommandHistory history = new CommandHistory();
+
     private Model model = new ModelManager();
     private Model expectedModel = new ModelManager();
 
     @Test
     public void executeWithNoCommand_success() {
         HelpCommand helpCommand = new HelpCommand("");
-        assertCommandSuccess(helpCommand, model, HelpCommand.MESSAGE_GENERAL_HELP, expectedModel);
+        assertCommandSuccess(helpCommand, model, history, HelpCommand.MESSAGE_GENERAL_HELP, expectedModel);
 
         HelpCommand helpCommandWithSpace = new HelpCommand(" ");
-        assertCommandSuccess(helpCommandWithSpace, model, HelpCommand.MESSAGE_GENERAL_HELP, expectedModel);
+        assertCommandSuccess(helpCommandWithSpace, model, history, HelpCommand.MESSAGE_GENERAL_HELP, expectedModel);
 
     }
 
     @Test
     public void executeWithValidCommand_success() {
         HelpCommand helpCommand = new HelpCommand(AddCommand.COMMAND_WORD);
-        assertCommandSuccess(helpCommand, model, AddCommand.HELP.getFullMessage(), expectedModel);
+        assertCommandSuccess(helpCommand, model, history, AddCommand.HELP.getFullMessage(), expectedModel);
 
         HelpCommand helpCommandWithSpace = new HelpCommand(AddCommand.COMMAND_WORD + " ");
-        assertCommandSuccess(helpCommandWithSpace, model, AddCommand.HELP.getFullMessage(), expectedModel);
+        assertCommandSuccess(helpCommandWithSpace, model, history, AddCommand.HELP.getFullMessage(), expectedModel);
 
         HelpCommand helpCommandForHelp = new HelpCommand(HelpCommand.COMMAND_WORD);
-        assertCommandSuccess(helpCommandForHelp, model, HelpCommand.HELP.getFullMessage(), expectedModel);
+        assertCommandSuccess(helpCommandForHelp, model, history, HelpCommand.HELP.getFullMessage(), expectedModel);
     }
 
     @Test
     public void executeWithInvalidCommand_failure() {
         String invalidCommand = "nonsenseCommand";
         HelpCommand helpCommand = new HelpCommand(invalidCommand);
-        assertCommandFailure(helpCommand, model, String.format(HelpCommand.MESSAGE_UNKNOWN_COMMAND, invalidCommand));
+        assertCommandFailure(helpCommand, model, history,
+                String.format(HelpCommand.MESSAGE_UNKNOWN_COMMAND, invalidCommand));
     }
 
 }

--- a/src/test/java/seedu/resireg/logic/commands/HistoryCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/HistoryCommandTest.java
@@ -1,0 +1,36 @@
+package seedu.resireg.logic.commands;
+
+import static seedu.resireg.logic.commands.CommandTestUtil.assertCommandSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.resireg.logic.CommandHistory;
+import seedu.resireg.model.Model;
+import seedu.resireg.model.ModelManager;
+
+public class HistoryCommandTest {
+    private CommandHistory history = new CommandHistory();
+
+    private Model model = new ModelManager();
+    private Model expectedModel = new ModelManager();
+
+    @Test
+    public void execute() {
+        assertCommandSuccess(new HistoryCommand(), model, history, HistoryCommand.MESSAGE_NO_HISTORY, expectedModel);
+
+        String firstCommand = "rooms";
+        history.add(firstCommand);
+        assertCommandSuccess(new HistoryCommand(), model, history,
+                String.format(HistoryCommand.MESSAGE_SUCCESS, firstCommand), expectedModel);
+
+        String secondCommand = "invalid";
+        String thirdCommand = "clear";
+        history.add(secondCommand);
+        history.add(thirdCommand);
+
+        String expectedMessage = String.format(HistoryCommand.MESSAGE_SUCCESS,
+                String.join("\n", thirdCommand, secondCommand, firstCommand));
+        assertCommandSuccess(new HistoryCommand(), model, history, expectedMessage, expectedModel);
+    }
+
+}

--- a/src/test/java/seedu/resireg/logic/commands/ListAliasCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/ListAliasCommandTest.java
@@ -7,6 +7,7 @@ import static seedu.resireg.testutil.TypicalStudents.getTypicalResiReg;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
 import seedu.resireg.model.ResiReg;
@@ -16,6 +17,8 @@ import seedu.resireg.model.UserPrefs;
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
  */
 public class ListAliasCommandTest {
+
+    private CommandHistory history = new CommandHistory();
 
     private Model fullModel;
     private Model expectedFullModel;
@@ -34,14 +37,14 @@ public class ListAliasCommandTest {
 
     @Test
     public void execute_listExists_showsSameList() {
-        assertCommandSuccess(new ListAliasCommand(), fullModel,
+        assertCommandSuccess(new ListAliasCommand(), fullModel, history,
             String.format(ListAliasCommand.MESSAGE_SUCCESS, fullModel.getCommandWordAliasesAsString()),
             expectedFullModel);
     }
 
     @Test
     public void execute_listIsEmpty_showsEmptyMessage() {
-        assertCommandSuccess(new ListAliasCommand(), emptyModel,
+        assertCommandSuccess(new ListAliasCommand(), emptyModel, history,
             ListAliasCommand.MESSAGE_EMPTY_ALIAS, expectedEmptyModel);
     }
 }

--- a/src/test/java/seedu/resireg/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/ListCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.resireg.testutil.TypicalStudents.getTypicalResiReg;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
 import seedu.resireg.model.UserPrefs;
@@ -17,6 +18,7 @@ import seedu.resireg.model.UserPrefs;
  */
 public class ListCommandTest {
 
+    private CommandHistory history = new CommandHistory();
     private Model model;
     private Model expectedModel;
 
@@ -28,12 +30,12 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(), model, history, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showStudentAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(), model, history, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/resireg/logic/commands/ListRoomCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/ListRoomCommandTest.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.ListRoomCommand.RoomFilter;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
@@ -36,6 +37,9 @@ import seedu.resireg.testutil.RoomBuilder;
 import seedu.resireg.testutil.RoomFilterBuilder;
 
 public class ListRoomCommandTest {
+
+    private CommandHistory history = new CommandHistory();
+
     private Model model;
     private Model expectedModel;
 
@@ -106,7 +110,7 @@ public class ListRoomCommandTest {
     public void execute_listIsNotFiltered_showsSameList() {
         assertToggleCommandSuccess(
                 new ListRoomCommand(new RoomFilter()),
-                model, ListRoomCommand.MESSAGE_SUCCESS, expectedModel, TabView.ROOMS);
+                model, history, ListRoomCommand.MESSAGE_SUCCESS, expectedModel, TabView.ROOMS);
     }
 
     @Test
@@ -116,6 +120,7 @@ public class ListRoomCommandTest {
         assertToggleCommandSuccess(
                 cmd,
                 model,
+                history,
                 ListRoomCommand.MESSAGE_FILTERED_SUCCESS, expectedModel, TabView.ROOMS);
     }
 
@@ -126,6 +131,7 @@ public class ListRoomCommandTest {
         assertToggleCommandSuccess(
                 cmd,
                 model,
+                history,
                 ListRoomCommand.MESSAGE_FILTERED_SUCCESS, expectedModel, TabView.ROOMS);
     }
 
@@ -137,6 +143,7 @@ public class ListRoomCommandTest {
         assertToggleCommandSuccess(
                 cmd,
                 model,
+                history,
                 ListRoomCommand.MESSAGE_FILTERED_SUCCESS, expectedModel, TabView.ROOMS);
     }
 
@@ -148,6 +155,7 @@ public class ListRoomCommandTest {
         assertToggleCommandSuccess(
                 cmd,
                 model,
+                history,
                 ListRoomCommand.MESSAGE_FILTERED_SUCCESS, expectedModel, TabView.ROOMS);
     }
 
@@ -159,6 +167,7 @@ public class ListRoomCommandTest {
         assertToggleCommandSuccess(
                 cmd,
                 model,
+                history,
                 ListRoomCommand.MESSAGE_FILTERED_SUCCESS, expectedModel, TabView.ROOMS);
     }
 
@@ -170,6 +179,7 @@ public class ListRoomCommandTest {
         assertToggleCommandSuccess(
                 cmd,
                 model,
+                history,
                 ListRoomCommand.MESSAGE_FILTERED_SUCCESS, expectedModel, TabView.ROOMS);
     }
 
@@ -181,6 +191,7 @@ public class ListRoomCommandTest {
         assertToggleCommandSuccess(
                 cmd,
                 model,
+                history,
                 ListRoomCommand.MESSAGE_FILTERED_SUCCESS, expectedModel, TabView.ROOMS);
     }
 
@@ -193,6 +204,7 @@ public class ListRoomCommandTest {
         assertToggleCommandSuccess(
                 cmd,
                 model,
+                history,
                 ListRoomCommand.MESSAGE_FILTERED_SUCCESS, expectedModel, TabView.ROOMS);
     }
 
@@ -205,6 +217,7 @@ public class ListRoomCommandTest {
         assertToggleCommandSuccess(
                 cmd,
                 model,
+                history,
                 ListRoomCommand.MESSAGE_FILTERED_SUCCESS, expectedModel, TabView.ROOMS);
     }
 }

--- a/src/test/java/seedu/resireg/logic/commands/ReallocateCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/ReallocateCommandTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.resireg.commons.core.Messages;
 import seedu.resireg.commons.core.index.Index;
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
 import seedu.resireg.model.UserPrefs;
@@ -34,6 +35,8 @@ import seedu.resireg.model.student.Student;
  * is free to be allocated.
  */
 public class ReallocateCommandTest {
+
+    private CommandHistory history = new CommandHistory();
 
     private Model model = new ModelManager(getTypicalResiReg(), new UserPrefs());
 
@@ -62,21 +65,21 @@ public class ReallocateCommandTest {
         expectedModel.setAllocation(toReallocate, editedAllocate);
         expectedModel.saveStateResiReg();
 
-        assertCommandSuccess(allocateCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(allocateCommand, model, history, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_invalidIndexStudentUnfilteredList_throwsCommandException() {
         Index outOfBoundIndexStudent = Index.fromOneBased(model.getFilteredStudentList().size() + 1);
         ReallocateCommand reallocateCommand = new ReallocateCommand(outOfBoundIndexStudent, INDEX_FOURTH_ROOM);
-        assertCommandFailure(reallocateCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(reallocateCommand, model, history, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void execute_invalidIndexRoomUnfilteredList_throwsCommandException() {
         Index outOfBoundIndexRoom = Index.fromOneBased(model.getFilteredRoomList().size() + 1);
         ReallocateCommand reallocateCommand = new ReallocateCommand(INDEX_FIRST_PERSON, outOfBoundIndexRoom);
-        assertCommandFailure(reallocateCommand, model, Messages.MESSAGE_INVALID_ROOM_DISPLAYED_INDEX);
+        assertCommandFailure(reallocateCommand, model, history, Messages.MESSAGE_INVALID_ROOM_DISPLAYED_INDEX);
     }
 
     @Test
@@ -86,7 +89,7 @@ public class ReallocateCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getResiReg().getStudentList().size());
         ReallocateCommand reallocateCommand = new ReallocateCommand(outOfBoundIndex, INDEX_FOURTH_ROOM);
-        assertCommandFailure(reallocateCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(reallocateCommand, model, history, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
@@ -96,7 +99,7 @@ public class ReallocateCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getResiReg().getRoomList().size());
         ReallocateCommand reallocateCommand = new ReallocateCommand(INDEX_FIRST_PERSON, outOfBoundIndex);
-        assertCommandFailure(reallocateCommand, model, Messages.MESSAGE_INVALID_ROOM_DISPLAYED_INDEX);
+        assertCommandFailure(reallocateCommand, model, history, Messages.MESSAGE_INVALID_ROOM_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/resireg/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/RedoCommandTest.java
@@ -8,11 +8,14 @@ import static seedu.resireg.testutil.TypicalStudents.getTypicalResiReg;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
 import seedu.resireg.model.UserPrefs;
 
 class RedoCommandTest {
+
+    private CommandHistory history = new CommandHistory();
 
     private final Model model = new ModelManager(getTypicalResiReg(), new UserPrefs());
     private final Model expectedModel = new ModelManager(getTypicalResiReg(), new UserPrefs());
@@ -35,13 +38,13 @@ class RedoCommandTest {
     public void execute() {
         // multiple redoable states in model
         expectedModel.redoResiReg();
-        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new RedoCommand(), model, history, RedoCommand.MESSAGE_SUCCESS, expectedModel);
 
         // single redoable state in model
         expectedModel.redoResiReg();
-        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new RedoCommand(), model, history, RedoCommand.MESSAGE_SUCCESS, expectedModel);
 
         // no redoable state in model
-        assertCommandFailure(new RedoCommand(), model, RedoCommand.MESSAGE_FAILURE);
+        assertCommandFailure(new RedoCommand(), model, history, RedoCommand.MESSAGE_FAILURE);
     }
 }

--- a/src/test/java/seedu/resireg/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/resireg/logic/commands/UndoCommandTest.java
@@ -8,11 +8,14 @@ import static seedu.resireg.testutil.TypicalStudents.getTypicalResiReg;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.model.Model;
 import seedu.resireg.model.ModelManager;
 import seedu.resireg.model.UserPrefs;
 
 class UndoCommandTest {
+
+    private CommandHistory history = new CommandHistory();
 
     private final Model model = new ModelManager(getTypicalResiReg(), new UserPrefs());
     private final Model expectedModel = new ModelManager(getTypicalResiReg(), new UserPrefs());
@@ -31,13 +34,13 @@ class UndoCommandTest {
     void execute() {
         // multiple undoable states in model
         expectedModel.undoResiReg();
-        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new UndoCommand(), model, history, UndoCommand.MESSAGE_SUCCESS, expectedModel);
 
         // single undoable state in model
         expectedModel.undoResiReg();
-        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new UndoCommand(), model, history, UndoCommand.MESSAGE_SUCCESS, expectedModel);
 
         // no undoable states remaining
-        assertCommandFailure(new UndoCommand(), model, UndoCommand.MESSAGE_FAILURE);
+        assertCommandFailure(new UndoCommand(), model, history, UndoCommand.MESSAGE_FAILURE);
     }
 }

--- a/src/test/java/seedu/resireg/logic/parser/ResiRegParserTest.java
+++ b/src/test/java/seedu/resireg/logic/parser/ResiRegParserTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.resireg.logic.CommandHistory;
 import seedu.resireg.logic.commands.Command;
 import seedu.resireg.logic.commands.CommandResult;
 import seedu.resireg.logic.commands.exceptions.CommandException;
@@ -28,7 +29,7 @@ public class ResiRegParserTest {
         }
 
         @Override
-        public CommandResult execute(Model model, Storage storage) throws CommandException {
+        public CommandResult execute(Model model, Storage storage, CommandHistory history) throws CommandException {
             throw new CommandException("unimplemented stub method");
         }
 

--- a/src/test/java/seedu/resireg/model/ResiRegTest.java
+++ b/src/test/java/seedu/resireg/model/ResiRegTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.beans.InvalidationListener;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.resireg.model.allocation.Allocation;
@@ -172,6 +173,16 @@ public class ResiRegTest {
         @Override
         public ObservableList<Allocation> getAllocationList() {
             return allocations;
+        }
+
+        @Override
+        public void addListener(InvalidationListener listener) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void removeListener(InvalidationListener listener) {
+            throw new AssertionError("This method should not be called.");
         }
     }
 

--- a/src/test/java/seedu/resireg/ui/ListPtrTest.java
+++ b/src/test/java/seedu/resireg/ui/ListPtrTest.java
@@ -1,0 +1,179 @@
+package seedu.resireg.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ListPtrTest {
+    private static final String FIRST = "first";
+    private static final String SECOND = "second";
+    private static final String THIRD = "third";
+    private List<String> ptrList;
+    private ListPtr ptr;
+
+    @BeforeEach
+    public void setUp() {
+        ptrList = new ArrayList<>();
+        ptrList.add(FIRST);
+        ptrList.add(SECOND);
+        ptrList.add(THIRD);
+    }
+
+    @Test
+    public void constructor_defensiveCopying_backingListUnmodified() {
+        List<String> list = new ArrayList<>();
+        ptr = new ListPtr(list);
+        list.add(FIRST);
+
+        ListPtr emptyPtr = new ListPtr(Collections.emptyList());
+        assertEquals(emptyPtr, ptr);
+    }
+
+    @Test
+    public void emptyList() {
+        ptr = new ListPtr(new ArrayList<>());
+        assertCurrFailure();
+        assertPrevFailure();
+        assertNextFailure();
+
+        ptr.add(FIRST);
+        assertNextSuccess(FIRST);
+    }
+
+    @Test
+    public void singletonList() {
+        List<String> list = new ArrayList<>();
+        list.add(FIRST);
+        ptr = new ListPtr(list);
+
+        assertCurrSuccess(FIRST);
+        assertPrevFailure();
+        assertCurrSuccess(FIRST);
+        assertNextFailure();
+        assertCurrSuccess(FIRST);
+
+        ptr.add(SECOND);
+        assertNextSuccess(SECOND);
+    }
+
+    @Test
+    public void multipleItemsList() {
+        ptr = new ListPtr(ptrList);
+        String fourth = "fourth";
+        ptr.add(fourth);
+
+        assertCurrSuccess(THIRD);
+
+        assertNextSuccess(fourth);
+        assertNextFailure();
+
+        assertPrevSuccess(THIRD);
+        assertPrevSuccess(SECOND);
+        assertPrevSuccess(FIRST);
+        assertPrevFailure();
+    }
+
+    @Test
+    public void equals() {
+        ListPtr firstPtr = new ListPtr(ptrList);
+
+        // same object -> returns true
+        assertTrue(firstPtr.equals(firstPtr));
+
+        // same values -> returns true
+        ListPtr copyOfFirstPtr = new ListPtr(ptrList);
+        assertTrue(firstPtr.equals(copyOfFirstPtr));
+
+        // different types -> returns false
+        assertFalse(firstPtr.equals("Jet"));
+
+        // null -> returns false
+        assertFalse(firstPtr.equals(null));
+
+        // different items -> returns false
+        ListPtr diffPtr = new ListPtr(Collections.singletonList(THIRD));
+        assertFalse(firstPtr.equals(diffPtr));
+
+        // different index -> returns false
+        copyOfFirstPtr.previous();
+        assertFalse(firstPtr.equals(copyOfFirstPtr));
+
+    }
+
+    /**
+     * Asserts that {@code ptr#hasNext()} returns true and the return value of
+     * {@code ptr#next()} equals to {@code item}
+     */
+    private void assertNextSuccess(String item) {
+        assertTrue(ptr.hasNext());
+        assertEquals(item, ptr.next());
+    }
+
+    /**
+     * Asserts that {@code ptr#hasPrevious()} returns true and the return value of
+     * {@code ptr#previous()} equals to {@code item}
+     */
+    private void assertPrevSuccess(String item) {
+        assertTrue(ptr.hasPrevious());
+        assertEquals(item, ptr.previous());
+    }
+
+    /**
+     * Asserts that {@code ptr#hasCurrent()} returns true and the return value of
+     * {@code ptr#current()} equals to {@code item}
+     */
+    private void assertCurrSuccess(String item) {
+        assertTrue(ptr.hasCurrent());
+        assertEquals(item, ptr.current());
+    }
+
+    /**
+     * Asserts that {@code ptr#hasNext()} returns false and the following
+     * {@code ptr#next()} call throws {@code NoSuchElementException}.
+     */
+    private void assertNextFailure() {
+        assertFalse(ptr.hasNext());
+        try {
+            ptr.next();
+            throw new AssertionError("The expected NoSuchElementException was not thrown.");
+        } catch (NoSuchElementException e) {
+            // expected exception thrown
+        }
+    }
+
+    /**
+     * Asserts that {@code ptr#hasPrevious()} returns false and the following
+     * {@code ptr#previous()} call throws {@code NoSuchElementException}.
+     */
+    private void assertPrevFailure() {
+        assertFalse(ptr.hasPrevious());
+        try {
+            ptr.previous();
+            throw new AssertionError("The expected NoSuchElementException was not thrown.");
+        } catch (NoSuchElementException e) {
+            // expected exception thrown
+        }
+    }
+
+    /**
+     * Asserts that {@code ptr#hasCurrent()} returns false and the following
+     * {@code ptr#current()} call throws {@code NoSuchElementException}.
+     */
+    private void assertCurrFailure() {
+        assertFalse(ptr.hasCurrent());
+        try {
+            ptr.current();
+            throw new AssertionError("The expected NoSuchElementException was not thrown.");
+        } catch (NoSuchElementException e) {
+            // expected exception thrown
+        }
+    }
+}


### PR DESCRIPTION
### What this does
This PR adds the command history functionality to ResiReg, allowing users to view their past commands in reverse chronological order. Users can also press <kbd>up</kbd> and <kbd>down</kbd> to cycle through the commands in the `CommandBox` (advance forward and backwards respectively).

<!-- Delete accordingly -->
Part of #30 

### How to test
<!-- Write an essay here if it's more suitable -->
1. Launch the application.
2. Type `history` in the command box and press <kbd>Enter</kbd>
3. Note that past commands appear in the results display
4. Press <kbd>up</kbd> and <kbd>down</kbd> to cycle through past commands entered

### Notes
<!-- Anything else we should take note of, e.g. how this affects future PRs,
issues faced, etc. -->

An `InvalidationListenerList` class, along with methods to add + remove listeners and indicate modifications made to `ResiReg` are created to improve performance, by only saving whenever modifications pertaining to `ResiReg` or `UserPrefs` are made. 

This also ensures that the test `execute_storageThrowsIoException_throwsCommandException()` passes by allowing the history to be updated as the method call to update history is not interrupted due to the throwing and catching of the IoException thrown.

This change also means that `ReadOnlyResiReg` is now made `Observable` so that `ResiReg` can notify listeners on changes made to itself. 

I am planning to shift away from showing the commands in the results display to actually having a list layout for past commands. Perhaps this can be done after the UI changes. 