### PR TITLE
Add unit tests for allocation-related classes

### DIFF
--- a/src/main/java/seedu/resireg/storage/JsonAdaptedAllocation.java
+++ b/src/main/java/seedu/resireg/storage/JsonAdaptedAllocation.java
@@ -56,7 +56,8 @@ class JsonAdaptedAllocation {
         final Floor modelFloor = new Floor(floor);
 
         if (roomNumber == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, RoomNumber.class.getSimpleName()));
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, RoomNumber.class.getSimpleName()));
         }
         if (!RoomNumber.isValidRoomNumber(roomNumber)) {
             throw new IllegalValueException(RoomNumber.MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/resireg/storage/JsonAdaptedAllocation.java
+++ b/src/main/java/seedu/resireg/storage/JsonAdaptedAllocation.java
@@ -56,7 +56,7 @@ class JsonAdaptedAllocation {
         final Floor modelFloor = new Floor(floor);
 
         if (roomNumber == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Number.class.getSimpleName()));
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, RoomNumber.class.getSimpleName()));
         }
         if (!RoomNumber.isValidRoomNumber(roomNumber)) {
             throw new IllegalValueException(RoomNumber.MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/resireg/logic/parser/AllocateCommandParserTest.java
+++ b/src/test/java/seedu/resireg/logic/parser/AllocateCommandParserTest.java
@@ -7,6 +7,7 @@ import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_ROOM;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.resireg.logic.commands.AllocateCommand;
 
 

--- a/src/test/java/seedu/resireg/logic/parser/AllocateCommandParserTest.java
+++ b/src/test/java/seedu/resireg/logic/parser/AllocateCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.resireg.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.resireg.logic.commands.AllocateCommand;
+
+import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_ROOM;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the AllocateCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the DeleteCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class AllocateCommandParserTest {
+
+    private AllocateCommandParser parser = new AllocateCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsAllocateCommand() {
+        assertParseSuccess(parser, " si/1 ri/1", new AllocateCommand(INDEX_FIRST_PERSON, INDEX_FIRST_ROOM));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AllocateCommand.HELP.getFullMessage()));
+    }
+}

--- a/src/test/java/seedu/resireg/logic/parser/AllocateCommandParserTest.java
+++ b/src/test/java/seedu/resireg/logic/parser/AllocateCommandParserTest.java
@@ -1,13 +1,14 @@
 package seedu.resireg.logic.parser;
 
-import org.junit.jupiter.api.Test;
-import seedu.resireg.logic.commands.AllocateCommand;
-
 import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_ROOM;
+
+import org.junit.jupiter.api.Test;
+import seedu.resireg.logic.commands.AllocateCommand;
+
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations

--- a/src/test/java/seedu/resireg/logic/parser/DeallocateCommandParserTest.java
+++ b/src/test/java/seedu/resireg/logic/parser/DeallocateCommandParserTest.java
@@ -1,12 +1,12 @@
 package seedu.resireg.logic.parser;
 
-import org.junit.jupiter.api.Test;
-import seedu.resireg.logic.commands.DeallocateCommand;
-
 import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+import seedu.resireg.logic.commands.DeallocateCommand;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations

--- a/src/test/java/seedu/resireg/logic/parser/DeallocateCommandParserTest.java
+++ b/src/test/java/seedu/resireg/logic/parser/DeallocateCommandParserTest.java
@@ -6,6 +6,7 @@ import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseSucces
 import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.resireg.logic.commands.DeallocateCommand;
 
 /**

--- a/src/test/java/seedu/resireg/logic/parser/DeallocateCommandParserTest.java
+++ b/src/test/java/seedu/resireg/logic/parser/DeallocateCommandParserTest.java
@@ -1,0 +1,32 @@
+package seedu.resireg.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.resireg.logic.commands.DeallocateCommand;
+
+import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the AllocateCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the DeleteCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class DeallocateCommandParserTest {
+
+    private DeallocateCommandParser parser = new DeallocateCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeallocateCommand() {
+        assertParseSuccess(parser, " si/1", new DeallocateCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeallocateCommand.HELP.getFullMessage()));
+    }
+}

--- a/src/test/java/seedu/resireg/logic/parser/ReallocateCommandParserTest.java
+++ b/src/test/java/seedu/resireg/logic/parser/ReallocateCommandParserTest.java
@@ -1,13 +1,14 @@
 package seedu.resireg.logic.parser;
 
-import org.junit.jupiter.api.Test;
-import seedu.resireg.logic.commands.ReallocateCommand;
-
 import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_ROOM;
+
+import org.junit.jupiter.api.Test;
+import seedu.resireg.logic.commands.ReallocateCommand;
+
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations

--- a/src/test/java/seedu/resireg/logic/parser/ReallocateCommandParserTest.java
+++ b/src/test/java/seedu/resireg/logic/parser/ReallocateCommandParserTest.java
@@ -7,6 +7,7 @@ import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_ROOM;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.resireg.logic.commands.ReallocateCommand;
 
 

--- a/src/test/java/seedu/resireg/logic/parser/ReallocateCommandParserTest.java
+++ b/src/test/java/seedu/resireg/logic/parser/ReallocateCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.resireg.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.resireg.logic.commands.ReallocateCommand;
+
+import static seedu.resireg.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.resireg.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.resireg.testutil.TypicalIndexes.INDEX_FIRST_ROOM;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the AllocateCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the DeleteCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class ReallocateCommandParserTest {
+
+    private ReallocateCommandParser parser = new ReallocateCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsReallocateCommand() {
+        assertParseSuccess(parser, " si/1 ri/1", new ReallocateCommand(INDEX_FIRST_PERSON, INDEX_FIRST_ROOM));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                ReallocateCommand.HELP.getFullMessage()));
+    }
+}

--- a/src/test/java/seedu/resireg/model/allocation/AllocationTest.java
+++ b/src/test/java/seedu/resireg/model/allocation/AllocationTest.java
@@ -1,0 +1,122 @@
+package seedu.resireg.model.allocation;
+
+import org.junit.jupiter.api.Test;
+import seedu.resireg.model.room.Room;
+import seedu.resireg.testutil.AllocationBuilder;
+import seedu.resireg.testutil.RoomBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_FLOOR_B;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ROOM_NUMBER_B;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ROOM_TYPE_B;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_TAG_DAMAGED;
+import static seedu.resireg.testutil.Assert.assertThrows;
+import static seedu.resireg.testutil.TypicalAllocations.ALLOCATION_ONE;
+import static seedu.resireg.testutil.TypicalAllocations.ALLOCATION_TWO;
+import static seedu.resireg.testutil.TypicalRooms.ROOM_A;
+import static seedu.resireg.testutil.TypicalRooms.ROOM_B;
+import static seedu.resireg.testutil.TypicalRooms.ROOM_TWO;
+import static seedu.resireg.testutil.TypicalStudents.ALICE;
+import static seedu.resireg.testutil.TypicalStudents.BENSON;
+
+public class AllocationTest {
+
+    @Test
+    public void asObservableList_modifyList_throwsUnsupportedOperationException() {
+        Allocation allocation = new AllocationBuilder().build();
+    }
+
+    @Test
+    public void isSameAllocation() {
+        // same object, returns true
+        assertTrue(ALLOCATION_ONE.isSameAllocation(ALLOCATION_ONE));
+
+        // null, returns false
+        assertFalse(ALLOCATION_ONE.isSameAllocation(null));
+
+        // different floor but same room number and student id -> returns true
+        Allocation editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
+                .withFloor(ROOM_TWO.getFloor().value)
+                .build();
+        assertTrue(ALLOCATION_ONE.isSameAllocation(editedAllocationOne));
+
+        // different room number but same floor and student id -> returns true
+        editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
+                .withRoomNumber(ROOM_TWO.getRoomNumber().value)
+                .build();
+        assertTrue(ALLOCATION_ONE.isSameAllocation(editedAllocationOne));
+
+        // different floor and room number but same student id -> returns true
+        editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
+                .withFloor(ROOM_TWO.getFloor().value)
+                .withRoomNumber(ROOM_TWO.getRoomNumber().value)
+                .build();
+        assertTrue(ALLOCATION_ONE.isSameAllocation(editedAllocationOne));
+
+        // different student id but same floor and room number -> returns true
+        editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
+                .withStudentId(BENSON.getStudentId().value)
+                .build();
+        assertTrue(ALLOCATION_ONE.isSameAllocation(editedAllocationOne));
+
+        // different student id and floor but same room number -> returns false
+        editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
+                .withFloor(ROOM_TWO.getFloor().value)
+                .withStudentId(BENSON.getStudentId().value)
+                .build();
+        assertFalse(ALLOCATION_ONE.isSameAllocation(editedAllocationOne));
+
+        // different student id and room number but same floor -> returns false
+        editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
+                .withRoomNumber(ROOM_TWO.getRoomNumber().value)
+                .withStudentId(BENSON.getStudentId().value)
+                .build();
+        assertFalse(ALLOCATION_ONE.isSameAllocation(editedAllocationOne));
+
+        // different floor, room number and student id -> returns false
+        editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
+                .withFloor(ROOM_TWO.getFloor().value)
+                .withRoomNumber(ROOM_TWO.getRoomNumber().value)
+                .withStudentId(BENSON.getStudentId().value)
+                .build();
+        assertFalse(ALLOCATION_ONE.isSameAllocation(editedAllocationOne));
+    }
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        Allocation allocationOneCopy = new AllocationBuilder(ALLOCATION_ONE).build();
+        assertTrue(ALLOCATION_ONE.equals(allocationOneCopy));
+
+        // same object -> returns true
+        assertTrue(ALLOCATION_ONE.equals(ALLOCATION_ONE));
+
+        // null -> returns false
+        assertFalse(ALLOCATION_ONE.equals(null));
+
+        // different type -> returns false
+        assertFalse(ALLOCATION_ONE.equals(7));
+
+        // different allocation -> returns false
+        assertFalse(ALLOCATION_ONE.equals(ALLOCATION_TWO));
+
+        // different floor -> returns false
+        Allocation editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
+                .withFloor(ROOM_TWO.getFloor().value)
+                .build();
+        assertFalse(ALLOCATION_ONE.equals(editedAllocationOne));
+
+        // different room number -> returns false
+        editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
+                .withRoomNumber(ROOM_TWO.getRoomNumber().value)
+                .build();
+        assertFalse(ALLOCATION_ONE.equals(editedAllocationOne));
+
+        // different student id -> returns false
+        editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
+                .withStudentId(BENSON.getStudentId().value)
+                .build();
+        assertFalse(ALLOCATION_ONE.equals(editedAllocationOne));
+    }
+}

--- a/src/test/java/seedu/resireg/model/allocation/AllocationTest.java
+++ b/src/test/java/seedu/resireg/model/allocation/AllocationTest.java
@@ -8,6 +8,7 @@ import static seedu.resireg.testutil.TypicalRooms.ROOM_TWO;
 import static seedu.resireg.testutil.TypicalStudents.BENSON;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.resireg.testutil.AllocationBuilder;
 
 

--- a/src/test/java/seedu/resireg/model/allocation/AllocationTest.java
+++ b/src/test/java/seedu/resireg/model/allocation/AllocationTest.java
@@ -1,24 +1,15 @@
 package seedu.resireg.model.allocation;
 
-import org.junit.jupiter.api.Test;
-import seedu.resireg.model.room.Room;
-import seedu.resireg.testutil.AllocationBuilder;
-import seedu.resireg.testutil.RoomBuilder;
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.resireg.logic.commands.CommandTestUtil.VALID_FLOOR_B;
-import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ROOM_NUMBER_B;
-import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ROOM_TYPE_B;
-import static seedu.resireg.logic.commands.CommandTestUtil.VALID_TAG_DAMAGED;
-import static seedu.resireg.testutil.Assert.assertThrows;
 import static seedu.resireg.testutil.TypicalAllocations.ALLOCATION_ONE;
 import static seedu.resireg.testutil.TypicalAllocations.ALLOCATION_TWO;
-import static seedu.resireg.testutil.TypicalRooms.ROOM_A;
-import static seedu.resireg.testutil.TypicalRooms.ROOM_B;
 import static seedu.resireg.testutil.TypicalRooms.ROOM_TWO;
-import static seedu.resireg.testutil.TypicalStudents.ALICE;
 import static seedu.resireg.testutil.TypicalStudents.BENSON;
+
+import org.junit.jupiter.api.Test;
+import seedu.resireg.testutil.AllocationBuilder;
+
 
 public class AllocationTest {
 

--- a/src/test/java/seedu/resireg/model/allocation/UniqueAllocationListTest.java
+++ b/src/test/java/seedu/resireg/model/allocation/UniqueAllocationListTest.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.resireg.model.allocation.exceptions.AllocationNotFoundException;
 import seedu.resireg.model.allocation.exceptions.DuplicateAllocationException;
 import seedu.resireg.testutil.AllocationBuilder;
@@ -74,14 +75,14 @@ public class UniqueAllocationListTest {
 
     @Test
     public void setAllocation_nullEditedAllocation_throwsNullPointerException() {
-        assertThrows(NullPointerException.class,
-            () -> uniqueAllocationList.setAllocation(ALLOCATION_ONE, null));
+        assertThrows(NullPointerException.class, () ->
+            uniqueAllocationList.setAllocation(ALLOCATION_ONE, null));
     }
 
     @Test
     public void setAllocation_targetAllocationNotInList_throwsAllocationNotFoundException() {
-        assertThrows(AllocationNotFoundException.class,
-            () -> uniqueAllocationList.setAllocation(ALLOCATION_ONE, ALLOCATION_ONE));
+        assertThrows(AllocationNotFoundException.class, () ->
+            uniqueAllocationList.setAllocation(ALLOCATION_ONE, ALLOCATION_ONE));
     }
 
     @Test
@@ -130,8 +131,8 @@ public class UniqueAllocationListTest {
     public void setAllocation_editedAllocationHasNonUniqueIdentity_throwsDuplicateAllocationException() {
         uniqueAllocationList.add(ALLOCATION_ONE);
         uniqueAllocationList.add(ALLOCATION_TWO);
-        assertThrows(DuplicateAllocationException.class,
-            () -> uniqueAllocationList.setAllocation(ALLOCATION_ONE, ALLOCATION_TWO));
+        assertThrows(DuplicateAllocationException.class, () ->
+                uniqueAllocationList.setAllocation(ALLOCATION_ONE, ALLOCATION_TWO));
     }
 
     @Test
@@ -154,8 +155,8 @@ public class UniqueAllocationListTest {
 
     @Test
     public void setAllocations_nullUniqueAllocationList_throwsNullPointerException() {
-        assertThrows(NullPointerException.class,
-            () -> uniqueAllocationList.setAllocations((UniqueAllocationList) null));
+        assertThrows(NullPointerException.class, () ->
+            uniqueAllocationList.setAllocations((UniqueAllocationList) null));
     }
 
     @Test

--- a/src/test/java/seedu/resireg/model/allocation/UniqueAllocationListTest.java
+++ b/src/test/java/seedu/resireg/model/allocation/UniqueAllocationListTest.java
@@ -1,0 +1,204 @@
+package seedu.resireg.model.allocation;
+
+import org.junit.jupiter.api.Test;
+import seedu.resireg.model.allocation.exceptions.AllocationNotFoundException;
+import seedu.resireg.model.allocation.exceptions.DuplicateAllocationException;
+import seedu.resireg.model.room.Room;
+import seedu.resireg.model.room.UniqueRoomList;
+import seedu.resireg.model.room.exceptions.DuplicateRoomException;
+import seedu.resireg.model.room.exceptions.RoomNotFoundException;
+import seedu.resireg.testutil.AllocationBuilder;
+import seedu.resireg.testutil.RoomBuilder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ROOM_TYPE_B;
+import static seedu.resireg.logic.commands.CommandTestUtil.VALID_TAG_DAMAGED;
+import static seedu.resireg.testutil.Assert.assertThrows;
+import static seedu.resireg.testutil.TypicalAllocations.ALLOCATION_ONE;
+import static seedu.resireg.testutil.TypicalAllocations.ALLOCATION_TWO;
+import static seedu.resireg.testutil.TypicalRooms.ROOM_A;
+import static seedu.resireg.testutil.TypicalRooms.ROOM_B;
+
+public class UniqueAllocationListTest {
+
+    private final UniqueAllocationList uniqueAllocationList = new UniqueAllocationList();
+
+    @Test
+    public void contains_nullAllocation_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueAllocationList.contains((Allocation) null));
+    }
+
+    @Test
+    public void contains_allocationNotInList_returnsFalse() {
+        assertFalse(uniqueAllocationList.contains(ALLOCATION_ONE));
+    }
+
+    @Test
+    public void contains_allocationInList_returnsTrue() {
+        uniqueAllocationList.add(ALLOCATION_ONE);
+        assertTrue(uniqueAllocationList.contains(ALLOCATION_ONE));
+    }
+
+    @Test
+    public void contains_allocationWithSameIdentityFieldsDifferentRoomNumberInList_returnsTrue() {
+        uniqueAllocationList.add(ALLOCATION_ONE);
+        Allocation editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
+                .withRoomNumber(ROOM_B.getRoomNumber().value)
+                .build();
+        assertTrue(uniqueAllocationList.contains(editedAllocationOne));
+    }
+
+    @Test
+    public void contains_allocationWithSameIdentityFieldsDifferentFloorInList_returnsTrue() {
+        uniqueAllocationList.add(ALLOCATION_ONE);
+        Allocation editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
+                .withFloor(ROOM_B.getFloor().value)
+                .build();
+        assertTrue(uniqueAllocationList.contains(editedAllocationOne));
+    }
+
+    @Test
+    public void add_nullAllocation_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueAllocationList.add(null));
+    }
+
+    @Test
+    public void add_duplicateAllocation_throwsDuplicateAllocationException() {
+        uniqueAllocationList.add(ALLOCATION_ONE);
+        assertThrows(DuplicateAllocationException.class, () -> uniqueAllocationList.add(ALLOCATION_ONE));
+    }
+
+    @Test
+    public void setAllocation_nullTargetAllocation_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueAllocationList.setAllocation(null, ALLOCATION_ONE));
+    }
+
+    @Test
+    public void setAllocation_nullEditedAllocation_throwsNullPointerException() {
+        assertThrows(NullPointerException.class,
+                () -> uniqueAllocationList.setAllocation(ALLOCATION_ONE, null));
+    }
+
+    @Test
+    public void setAllocation_targetAllocationNotInList_throwsAllocationNotFoundException() {
+        assertThrows(AllocationNotFoundException.class,
+                () -> uniqueAllocationList.setAllocation(ALLOCATION_ONE, ALLOCATION_ONE));
+    }
+
+    @Test
+    public void setAllocation_editedAllocationIsSameAllocation_success() {
+        uniqueAllocationList.add(ALLOCATION_ONE);
+        uniqueAllocationList.setAllocation(ALLOCATION_ONE, ALLOCATION_ONE);
+        UniqueAllocationList expectedUniqueAllocationList = new UniqueAllocationList();
+        expectedUniqueAllocationList.add(ALLOCATION_ONE);
+        assertEquals(expectedUniqueAllocationList, uniqueAllocationList);
+    }
+
+    @Test
+    public void setAllocation_editedAllocationHasSameIdentityDifferentFloor_success() {
+        uniqueAllocationList.add(ALLOCATION_ONE);
+        Allocation editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
+                .withFloor(ROOM_B.getFloor().value)
+                .build();
+        uniqueAllocationList.setAllocation(ALLOCATION_ONE, editedAllocationOne);
+        UniqueAllocationList expectedUniqueAllocationList = new UniqueAllocationList();
+        expectedUniqueAllocationList.add(editedAllocationOne);
+        assertEquals(expectedUniqueAllocationList, uniqueAllocationList);
+    }
+
+    @Test
+    public void setAllocation_editedAllocationHasSameIdentityDifferentRoomNumber_success() {
+        uniqueAllocationList.add(ALLOCATION_ONE);
+        Allocation editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
+                .withRoomNumber(ROOM_B.getRoomNumber().value)
+                .build();
+        uniqueAllocationList.setAllocation(ALLOCATION_ONE, editedAllocationOne);
+        UniqueAllocationList expectedUniqueAllocationList = new UniqueAllocationList();
+        expectedUniqueAllocationList.add(editedAllocationOne);
+        assertEquals(expectedUniqueAllocationList, uniqueAllocationList);
+    }
+
+    @Test
+    public void setAllocation_editedAllocationHasDifferentIdentity_success() {
+        uniqueAllocationList.add(ALLOCATION_ONE);
+        uniqueAllocationList.setAllocation(ALLOCATION_ONE, ALLOCATION_TWO);
+        UniqueAllocationList expectedUniqueAllocationList = new UniqueAllocationList();
+        expectedUniqueAllocationList.add(ALLOCATION_TWO);
+        assertEquals(expectedUniqueAllocationList, uniqueAllocationList);
+    }
+
+    @Test
+    public void setAllocation_editedAllocationHasNonUniqueIdentity_throwsDuplicateAllocationException() {
+        uniqueAllocationList.add(ALLOCATION_ONE);
+        uniqueAllocationList.add(ALLOCATION_TWO);
+        assertThrows(DuplicateAllocationException.class,
+                () -> uniqueAllocationList.setAllocation(ALLOCATION_ONE, ALLOCATION_TWO));
+    }
+
+    @Test
+    public void remove_nullAllocation_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueAllocationList.remove(null));
+    }
+
+    @Test
+    public void remove_AllocationDoesNotExist_throwsAllocationNotFoundException() {
+        assertThrows(AllocationNotFoundException.class, () -> uniqueAllocationList.remove(ALLOCATION_ONE));
+    }
+
+    @Test
+    public void remove_existingAllocation_removesAllocation() {
+        uniqueAllocationList.add(ALLOCATION_ONE);
+        uniqueAllocationList.remove(ALLOCATION_ONE);
+        UniqueAllocationList expectedUniqueAllocationList = new UniqueAllocationList();
+        assertEquals(expectedUniqueAllocationList, uniqueAllocationList);
+    }
+
+    @Test
+    public void setAllocations_nullUniqueAllocationList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class,
+                () -> uniqueAllocationList.setAllocations((UniqueAllocationList) null));
+    }
+
+    @Test
+    public void setAllocation_uniqueAllocationList_replacesOwnListWithProvidedUniqueAllocationList() {
+        uniqueAllocationList.add(ALLOCATION_ONE);
+        UniqueAllocationList expectedUniqueAllocationList = new UniqueAllocationList();
+        expectedUniqueAllocationList.add(ALLOCATION_ONE);
+        uniqueAllocationList.setAllocations(expectedUniqueAllocationList);
+        assertEquals(expectedUniqueAllocationList, uniqueAllocationList);
+    }
+
+    @Test
+    public void setAllocation_nullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueAllocationList.setAllocations((List<Allocation>) null));
+    }
+
+    @Test
+    public void setAllocations_list_replacesOwnListWithProvidedList() {
+        uniqueAllocationList.add(ALLOCATION_ONE);
+        List<Allocation> allocationList = Collections.singletonList(ALLOCATION_TWO);
+        uniqueAllocationList.setAllocations(allocationList);
+        UniqueAllocationList expectedUniqueAllocationList = new UniqueAllocationList();
+        expectedUniqueAllocationList.add(ALLOCATION_TWO);
+        assertEquals(expectedUniqueAllocationList, uniqueAllocationList);
+    }
+
+    @Test
+    public void setAllocations_listWithDuplicateAllocations_throwsDuplicateAllocationException() {
+        List<Allocation> listWithDuplicateAllocations = Arrays.asList(ALLOCATION_ONE, ALLOCATION_ONE);
+        assertThrows(DuplicateAllocationException.class,
+                () -> uniqueAllocationList.setAllocations(listWithDuplicateAllocations));
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, ()
+            -> uniqueAllocationList.asUnmodifiableObservableList().remove(0));
+    }
+}

--- a/src/test/java/seedu/resireg/model/allocation/UniqueAllocationListTest.java
+++ b/src/test/java/seedu/resireg/model/allocation/UniqueAllocationListTest.java
@@ -1,29 +1,22 @@
 package seedu.resireg.model.allocation;
 
-import org.junit.jupiter.api.Test;
-import seedu.resireg.model.allocation.exceptions.AllocationNotFoundException;
-import seedu.resireg.model.allocation.exceptions.DuplicateAllocationException;
-import seedu.resireg.model.room.Room;
-import seedu.resireg.model.room.UniqueRoomList;
-import seedu.resireg.model.room.exceptions.DuplicateRoomException;
-import seedu.resireg.model.room.exceptions.RoomNotFoundException;
-import seedu.resireg.testutil.AllocationBuilder;
-import seedu.resireg.testutil.RoomBuilder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.resireg.testutil.Assert.assertThrows;
+import static seedu.resireg.testutil.TypicalAllocations.ALLOCATION_ONE;
+import static seedu.resireg.testutil.TypicalAllocations.ALLOCATION_TWO;
+import static seedu.resireg.testutil.TypicalRooms.ROOM_B;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.resireg.logic.commands.CommandTestUtil.VALID_ROOM_TYPE_B;
-import static seedu.resireg.logic.commands.CommandTestUtil.VALID_TAG_DAMAGED;
-import static seedu.resireg.testutil.Assert.assertThrows;
-import static seedu.resireg.testutil.TypicalAllocations.ALLOCATION_ONE;
-import static seedu.resireg.testutil.TypicalAllocations.ALLOCATION_TWO;
-import static seedu.resireg.testutil.TypicalRooms.ROOM_A;
-import static seedu.resireg.testutil.TypicalRooms.ROOM_B;
+import org.junit.jupiter.api.Test;
+import seedu.resireg.model.allocation.exceptions.AllocationNotFoundException;
+import seedu.resireg.model.allocation.exceptions.DuplicateAllocationException;
+import seedu.resireg.testutil.AllocationBuilder;
+
 
 public class UniqueAllocationListTest {
 
@@ -49,8 +42,8 @@ public class UniqueAllocationListTest {
     public void contains_allocationWithSameIdentityFieldsDifferentRoomNumberInList_returnsTrue() {
         uniqueAllocationList.add(ALLOCATION_ONE);
         Allocation editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
-                .withRoomNumber(ROOM_B.getRoomNumber().value)
-                .build();
+            .withRoomNumber(ROOM_B.getRoomNumber().value)
+            .build();
         assertTrue(uniqueAllocationList.contains(editedAllocationOne));
     }
 
@@ -58,8 +51,8 @@ public class UniqueAllocationListTest {
     public void contains_allocationWithSameIdentityFieldsDifferentFloorInList_returnsTrue() {
         uniqueAllocationList.add(ALLOCATION_ONE);
         Allocation editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
-                .withFloor(ROOM_B.getFloor().value)
-                .build();
+            .withFloor(ROOM_B.getFloor().value)
+            .build();
         assertTrue(uniqueAllocationList.contains(editedAllocationOne));
     }
 
@@ -82,13 +75,13 @@ public class UniqueAllocationListTest {
     @Test
     public void setAllocation_nullEditedAllocation_throwsNullPointerException() {
         assertThrows(NullPointerException.class,
-                () -> uniqueAllocationList.setAllocation(ALLOCATION_ONE, null));
+            () -> uniqueAllocationList.setAllocation(ALLOCATION_ONE, null));
     }
 
     @Test
     public void setAllocation_targetAllocationNotInList_throwsAllocationNotFoundException() {
         assertThrows(AllocationNotFoundException.class,
-                () -> uniqueAllocationList.setAllocation(ALLOCATION_ONE, ALLOCATION_ONE));
+            () -> uniqueAllocationList.setAllocation(ALLOCATION_ONE, ALLOCATION_ONE));
     }
 
     @Test
@@ -104,8 +97,8 @@ public class UniqueAllocationListTest {
     public void setAllocation_editedAllocationHasSameIdentityDifferentFloor_success() {
         uniqueAllocationList.add(ALLOCATION_ONE);
         Allocation editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
-                .withFloor(ROOM_B.getFloor().value)
-                .build();
+            .withFloor(ROOM_B.getFloor().value)
+            .build();
         uniqueAllocationList.setAllocation(ALLOCATION_ONE, editedAllocationOne);
         UniqueAllocationList expectedUniqueAllocationList = new UniqueAllocationList();
         expectedUniqueAllocationList.add(editedAllocationOne);
@@ -116,8 +109,8 @@ public class UniqueAllocationListTest {
     public void setAllocation_editedAllocationHasSameIdentityDifferentRoomNumber_success() {
         uniqueAllocationList.add(ALLOCATION_ONE);
         Allocation editedAllocationOne = new AllocationBuilder(ALLOCATION_ONE)
-                .withRoomNumber(ROOM_B.getRoomNumber().value)
-                .build();
+            .withRoomNumber(ROOM_B.getRoomNumber().value)
+            .build();
         uniqueAllocationList.setAllocation(ALLOCATION_ONE, editedAllocationOne);
         UniqueAllocationList expectedUniqueAllocationList = new UniqueAllocationList();
         expectedUniqueAllocationList.add(editedAllocationOne);
@@ -138,7 +131,7 @@ public class UniqueAllocationListTest {
         uniqueAllocationList.add(ALLOCATION_ONE);
         uniqueAllocationList.add(ALLOCATION_TWO);
         assertThrows(DuplicateAllocationException.class,
-                () -> uniqueAllocationList.setAllocation(ALLOCATION_ONE, ALLOCATION_TWO));
+            () -> uniqueAllocationList.setAllocation(ALLOCATION_ONE, ALLOCATION_TWO));
     }
 
     @Test
@@ -162,7 +155,7 @@ public class UniqueAllocationListTest {
     @Test
     public void setAllocations_nullUniqueAllocationList_throwsNullPointerException() {
         assertThrows(NullPointerException.class,
-                () -> uniqueAllocationList.setAllocations((UniqueAllocationList) null));
+            () -> uniqueAllocationList.setAllocations((UniqueAllocationList) null));
     }
 
     @Test
@@ -193,12 +186,12 @@ public class UniqueAllocationListTest {
     public void setAllocations_listWithDuplicateAllocations_throwsDuplicateAllocationException() {
         List<Allocation> listWithDuplicateAllocations = Arrays.asList(ALLOCATION_ONE, ALLOCATION_ONE);
         assertThrows(DuplicateAllocationException.class,
-                () -> uniqueAllocationList.setAllocations(listWithDuplicateAllocations));
+            () -> uniqueAllocationList.setAllocations(listWithDuplicateAllocations));
     }
 
     @Test
     public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class, ()
-            -> uniqueAllocationList.asUnmodifiableObservableList().remove(0));
+        assertThrows(UnsupportedOperationException.class,
+            () -> uniqueAllocationList.asUnmodifiableObservableList().remove(0));
     }
 }

--- a/src/test/java/seedu/resireg/model/allocation/UniqueAllocationListTest.java
+++ b/src/test/java/seedu/resireg/model/allocation/UniqueAllocationListTest.java
@@ -141,7 +141,7 @@ public class UniqueAllocationListTest {
     }
 
     @Test
-    public void remove_AllocationDoesNotExist_throwsAllocationNotFoundException() {
+    public void remove_allocationDoesNotExist_throwsAllocationNotFoundException() {
         assertThrows(AllocationNotFoundException.class, () -> uniqueAllocationList.remove(ALLOCATION_ONE));
     }
 
@@ -186,13 +186,13 @@ public class UniqueAllocationListTest {
     @Test
     public void setAllocations_listWithDuplicateAllocations_throwsDuplicateAllocationException() {
         List<Allocation> listWithDuplicateAllocations = Arrays.asList(ALLOCATION_ONE, ALLOCATION_ONE);
-        assertThrows(DuplicateAllocationException.class,
-            () -> uniqueAllocationList.setAllocations(listWithDuplicateAllocations));
+        assertThrows(DuplicateAllocationException.class, () ->
+            uniqueAllocationList.setAllocations(listWithDuplicateAllocations));
     }
 
     @Test
     public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class,
-            () -> uniqueAllocationList.asUnmodifiableObservableList().remove(0));
+        assertThrows(UnsupportedOperationException.class, () ->
+            uniqueAllocationList.asUnmodifiableObservableList().remove(0));
     }
 }

--- a/src/test/java/seedu/resireg/storage/JsonAdaptedAllocationTest.java
+++ b/src/test/java/seedu/resireg/storage/JsonAdaptedAllocationTest.java
@@ -1,0 +1,78 @@
+package seedu.resireg.storage;
+
+import org.junit.jupiter.api.Test;
+import seedu.resireg.commons.exceptions.IllegalValueException;
+import seedu.resireg.model.room.Floor;
+import seedu.resireg.model.room.RoomNumber;
+import seedu.resireg.model.student.StudentId;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.resireg.storage.JsonAdaptedAllocation.MISSING_FIELD_MESSAGE_FORMAT;
+import static seedu.resireg.testutil.Assert.assertThrows;
+import static seedu.resireg.testutil.TypicalAllocations.ALLOCATION_ONE;
+import static seedu.resireg.testutil.TypicalRooms.ROOM_ONE;
+import static seedu.resireg.testutil.TypicalStudents.AMY;
+
+class JsonAdaptedAllocationTest {
+    private static final String INVALID_FLOOR = "08";
+    private static final String INVALID_NUMBER = "0110";
+    private static final String INVALID_STUDENT_ID = "e0000000";
+
+    private static final String VALID_FLOOR = ROOM_ONE.getFloor().toString();
+    private static final String VALID_NUMBER = ROOM_ONE.getRoomNumber().toString();
+    private static final String VALID_STUDENT_ID = AMY.getStudentId().toString();
+
+    @Test
+    void toModelType_validAllocationDetails_returnsAllocation() throws Exception {
+        JsonAdaptedAllocation allocation = new JsonAdaptedAllocation(ALLOCATION_ONE);
+        assertEquals(ALLOCATION_ONE, allocation.toModelType());
+    }
+
+    @Test
+    public void toModelType_invalidFloor_throwsIllegalValueException() {
+        JsonAdaptedAllocation allocation =
+                new JsonAdaptedAllocation(INVALID_FLOOR, VALID_NUMBER, VALID_STUDENT_ID);
+        String expectedMessage = Floor.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, allocation::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullFloor_throwsIllegalValueException() {
+        JsonAdaptedAllocation allocation =
+                new JsonAdaptedAllocation(null, VALID_NUMBER, VALID_STUDENT_ID);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Floor.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, allocation::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidNumber_throwsIllegalValueException() {
+        JsonAdaptedAllocation allocation =
+                new JsonAdaptedAllocation(VALID_FLOOR, INVALID_NUMBER, VALID_STUDENT_ID);
+        String expectedMessage = RoomNumber.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, allocation::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullNumber_throwsIllegalValueException() {
+        JsonAdaptedAllocation allocation =
+                new JsonAdaptedAllocation(VALID_FLOOR, null, VALID_STUDENT_ID);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, RoomNumber.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, allocation::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidStudentId_throwsIllegalValueException() {
+        JsonAdaptedAllocation allocation =
+                new JsonAdaptedAllocation(VALID_FLOOR, VALID_NUMBER, INVALID_STUDENT_ID);
+        String expectedMessage = StudentId.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, allocation::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullStudentId_throwsIllegalValueException() {
+        JsonAdaptedAllocation allocation =
+                new JsonAdaptedAllocation(VALID_FLOOR, VALID_NUMBER, null);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, StudentId.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, allocation::toModelType);
+    }
+}

--- a/src/test/java/seedu/resireg/storage/JsonAdaptedAllocationTest.java
+++ b/src/test/java/seedu/resireg/storage/JsonAdaptedAllocationTest.java
@@ -1,17 +1,18 @@
 package seedu.resireg.storage;
 
-import org.junit.jupiter.api.Test;
-import seedu.resireg.commons.exceptions.IllegalValueException;
-import seedu.resireg.model.room.Floor;
-import seedu.resireg.model.room.RoomNumber;
-import seedu.resireg.model.student.StudentId;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.resireg.storage.JsonAdaptedAllocation.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.resireg.testutil.Assert.assertThrows;
 import static seedu.resireg.testutil.TypicalAllocations.ALLOCATION_ONE;
 import static seedu.resireg.testutil.TypicalRooms.ROOM_ONE;
 import static seedu.resireg.testutil.TypicalStudents.AMY;
+
+import org.junit.jupiter.api.Test;
+import seedu.resireg.commons.exceptions.IllegalValueException;
+import seedu.resireg.model.room.Floor;
+import seedu.resireg.model.room.RoomNumber;
+import seedu.resireg.model.student.StudentId;
+
 
 class JsonAdaptedAllocationTest {
     private static final String INVALID_FLOOR = "08";

--- a/src/test/java/seedu/resireg/storage/JsonAdaptedAllocationTest.java
+++ b/src/test/java/seedu/resireg/storage/JsonAdaptedAllocationTest.java
@@ -8,6 +8,7 @@ import static seedu.resireg.testutil.TypicalRooms.ROOM_ONE;
 import static seedu.resireg.testutil.TypicalStudents.AMY;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.resireg.commons.exceptions.IllegalValueException;
 import seedu.resireg.model.room.Floor;
 import seedu.resireg.model.room.RoomNumber;

--- a/src/test/java/seedu/resireg/testutil/RoomBuilder.java
+++ b/src/test/java/seedu/resireg/testutil/RoomBuilder.java
@@ -23,7 +23,6 @@ public class RoomBuilder {
     private Floor floor;
     private RoomNumber roomNumber;
     private RoomType roomType;
-    private Student student;
     private Set<Tag> tags;
 
     /**
@@ -75,14 +74,6 @@ public class RoomBuilder {
      */
     public RoomBuilder withRoomNumber(String number) {
         this.roomNumber = new RoomNumber(number);
-        return this;
-    }
-
-    /**
-     * Sets the {@code RoomNumber} of the {@code Room} that we are building.
-     */
-    public RoomBuilder withStudent(Student student) {
-        this.student = student;
         return this;
     }
 

--- a/src/test/java/seedu/resireg/testutil/RoomBuilder.java
+++ b/src/test/java/seedu/resireg/testutil/RoomBuilder.java
@@ -7,7 +7,6 @@ import seedu.resireg.model.room.Floor;
 import seedu.resireg.model.room.Room;
 import seedu.resireg.model.room.RoomNumber;
 import seedu.resireg.model.room.roomtype.RoomType;
-import seedu.resireg.model.student.Student;
 import seedu.resireg.model.tag.Tag;
 import seedu.resireg.model.util.SampleDataUtil;
 


### PR DESCRIPTION
### What this does
This PR adds unit testing support for `Allocation`, `AllocateCommandParser`, `DeallocateCommandParser`, `ReallocateCommandParser`, `UniqueAllocationList` and `JsonAdaptedAllocation`.

<!-- Delete accordingly -->
Part of #13, #14 and #18.

### How to test
N/A

### Notes
N/A
