### PR TITLE
Make supported OSes clear in UG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -794,7 +794,7 @@ Similar to <u>UC03 - edit a student</u>, just replace student with room.
 
 ### Glossary
 
-- **Mainstream OS**: Windows, Linux, Unix, OS-X
+- **Mainstream OS**: Windows, Linux, OS-X
 - **OHS**: Office of Housing Services at the National University of Singapore (NUS)
 - **OHS Admin**: An employee of the OHS who works at a Residential College at NUS
 - **Residential College**: A university residence for students that offers a 2-year program at NUS

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -34,7 +34,9 @@ You may refer to [Quick Start](#quick-start) for a short tutorial on how to run 
 
 ## Quick Start
 
-1. Ensure that Java 11 or above is installed in your computer
+> **ResiReg** runs on Windows, Linux, and OS-X.
+
+1. Ensure that Java 11 or above is installed in your computer.
 2. Download the latest `ResiReg.jar` here.
 3. Copy the file to the folder you want to use as the home folder for your **ResiReg**.
 4. Double-click the file to start the app. The app window should open in a few seconds.


### PR DESCRIPTION
### What this does
This PR <!-- your WCT essay here -->makes it clear what Operating Systems are supported in our User Guide, to avoid any confusion.

<!-- Delete accordingly -->
Fixes #154 .

### How to test
<!-- Write an essay here if it's more suitable -->
Just read the diff.

### Notes
<!-- Anything else we should take note of, e.g. how this affects future PRs,
issues faced, etc. -->
I removed Unix from the Mainstream OS definition in DG as well. It's not wrong, just not helpful to our DG, and we don't get to test on the BSDs etc.