### PR TITLE
Bug Fix: Reallocate allows allocation of different students to the same room.

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -123,7 +123,6 @@ Examples:
 
 - `allocate ri/1 si/1` allocates the room at `room_index` 1 to the student at `student_index` 1.
 
-#### Deallocating a room for a student : `deallocate`
 ##### Before allocation
 
 <img src="images/BeforeAllocation.png">
@@ -132,6 +131,7 @@ Examples:
 
 <img src="images/AfterAllocation.png">
 
+#### Deallocating a room for a student : `deallocate`
 
 Deallocates a room for a student i.e denotes that the student no longer occupies the room.
 

--- a/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/AllocateCommand.java
@@ -36,6 +36,9 @@ public class AllocateCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Room %1$s allocated to %2$s.";
     public static final String MESSAGE_ROOM_NOT_FOUND = "This room does not exist in ResiReg";
     public static final String MESSAGE_STUDENT_NOT_FOUND = "This student is not registered in ResiReg";
+    public static final String MESSAGE_STUDENT_ALREADY_ALLOCATED =
+            "This student has already been allocated in Resireg.";
+    public static final String MESSAGE_ROOM_ALREADY_ALLOCATED = "This room has already been allocated in Resireg.";
     public static final String MESSAGE_ALLOCATION_EXISTS = "This allocation has already been registered in ResiReg.";
 
     private final Index studentIndex;
@@ -59,6 +62,7 @@ public class AllocateCommand extends Command {
         requireNonNull(model);
         List<Student> lastShownListStudent = model.getFilteredStudentList();
         List<Room> lastShownListRoom = model.getFilteredRoomList();
+        List<Allocation> lastShownListAllocation = model.getFilteredAllocationList();
 
         if (studentIndex.getZeroBased() >= lastShownListStudent.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -75,6 +79,10 @@ public class AllocateCommand extends Command {
             throw new CommandException(MESSAGE_STUDENT_NOT_FOUND);
         } else if (!model.hasRoom(roomToAllocate)) {
             throw new CommandException(MESSAGE_ROOM_NOT_FOUND);
+        } else if (model.isAllocated(studentToAllocate)) {
+            throw new CommandException(MESSAGE_STUDENT_ALREADY_ALLOCATED);
+        } else if (model.isAllocated(roomToAllocate)) {
+            throw new CommandException(MESSAGE_ROOM_ALREADY_ALLOCATED);
         } else if (model.hasAllocation(toAllocate)) {
             throw new CommandException(MESSAGE_ALLOCATION_EXISTS);
         }

--- a/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
+++ b/src/main/java/seedu/resireg/logic/commands/ReallocateCommand.java
@@ -33,6 +33,8 @@ public class ReallocateCommand extends Command {
     public static final String MESSAGE_STUDENT_NOT_ALLOCATED =
             "This student has not been allocated a room. Please use allocate instead.";
     public static final String MESSAGE_SAME_ROOM_ALLOCATED = "This room has already been allocated to the student.";
+    public static final String MESSAGE_ROOM_ALREADY_ALLOCATED =
+            "This room has already been allocated to another student.";
 
     private final Index studentIndex;
     private final Index roomIndex;
@@ -81,12 +83,16 @@ public class ReallocateCommand extends Command {
             throw new CommandException(MESSAGE_STUDENT_NOT_ALLOCATED);
         } else if (toReallocate.isRelatedTo(roomToReallocate)) {
             throw new CommandException(MESSAGE_SAME_ROOM_ALLOCATED);
+        } else if (model.isAllocated(roomToReallocate)) {
+            throw new CommandException(MESSAGE_ROOM_ALREADY_ALLOCATED);
         }
 
-        Allocation editedAllocation = new Allocation(roomToReallocate.getFloor(), roomToReallocate.getRoomNumber(),
-                        studentToReallocate.getStudentId());
-        model.setAllocation(toReallocate, editedAllocation);
+        Allocation editedAllocation = new Allocation(
+            roomToReallocate.getFloor(),
+            roomToReallocate.getRoomNumber(),
+            studentToReallocate.getStudentId());
 
+        model.setAllocation(toReallocate, editedAllocation);
         model.saveStateResiReg();
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, studentToReallocate.getNameAsString(),

--- a/src/main/java/seedu/resireg/model/ResiReg.java
+++ b/src/main/java/seedu/resireg/model/ResiReg.java
@@ -194,7 +194,7 @@ public class ResiReg implements ReadOnlyResiReg {
      */
     public boolean isAllocated(Student student) {
         requireNonNull(student);
-        return allocations.contains(student);
+        return allocations.hasStudent(student);
     }
 
     /**
@@ -202,7 +202,7 @@ public class ResiReg implements ReadOnlyResiReg {
      */
     public boolean isAllocated(Room room) {
         requireNonNull(room);
-        return allocations.contains(room);
+        return allocations.hasRoom(room);
     }
 
 

--- a/src/main/java/seedu/resireg/model/allocation/Allocation.java
+++ b/src/main/java/seedu/resireg/model/allocation/Allocation.java
@@ -62,6 +62,23 @@ public class Allocation {
     }
 
     /**
+     * Returns true if both allocations have the same student.
+     */
+    public boolean hasSameStudent(Allocation otherAllocation) {
+        return otherAllocation != null
+                && otherAllocation.getStudentId().equals(getStudentId());
+    }
+
+    /**
+     * Returns true if both allocations have the same room.
+     */
+    public boolean hasSameRoom(Allocation otherAllocation) {
+        return otherAllocation != null
+                && otherAllocation.getFloor().equals(getFloor())
+                && otherAllocation.getRoomNumber().equals(getFloor());
+    }
+
+    /**
      * Returns true if both allocations have the same room identification (floor and roomNumber).
      * This defines a weaker notion of equality between two allocations
      */

--- a/src/main/java/seedu/resireg/model/allocation/UniqueAllocationList.java
+++ b/src/main/java/seedu/resireg/model/allocation/UniqueAllocationList.java
@@ -42,7 +42,7 @@ public class UniqueAllocationList implements Iterable<Allocation> {
     /**
      * Returns true if the allocation list contains the {@code student} identifier.
      */
-    public boolean contains(Student student) {
+    public boolean hasStudent(Student student) {
         for (Allocation allocation : internalList) {
             if (allocation.getStudentId().equals(student.getStudentId())) {
                 return true;
@@ -54,7 +54,7 @@ public class UniqueAllocationList implements Iterable<Allocation> {
     /**
      * Returns true if the allocation list contains the {@code room} identifier.
      */
-    public boolean contains(Room room) {
+    public boolean hasRoom(Room room) {
         for (Allocation allocation : internalList) {
             if (allocation.getFloor().equals(room.getFloor())
                     && allocation.getRoomNumber().equals(room.getRoomNumber())) {


### PR DESCRIPTION
### What this does
This PR fixes the bug where `reallocate` command allows allocation of different students to the same room, and fixes minor documentation issues.

<!-- Delete accordingly -->
Fixes #140, #141, #149, #161.

### How to test
<!-- Write an essay here if it's more suitable -->
1. Launch the application.
2. Run `allocate si/1 ri/1`.
3. Run `allocate si/2 ri/2`.
4. Run `reallocate si/2 ri/1`.
5. Ensure that the error message "This room has already been allocated to another student." appears.

### Notes
Screenshot:
![image](https://user-images.githubusercontent.com/27071473/97807419-97f73000-1c9b-11eb-8db2-32ad529e4857.png)
