### PR TITLE
Bug Fix: Fix room number error message and add-room UG details

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -82,8 +82,8 @@ Examples:
 Adds a room to ResiReg. The following room details are stored: room floor, room number, room type, and optionally, tags.
 
 Format: `add-room fl/<floor> n/<room_number> t/<room_type> [tag/<tag_name>]...`
-- Floor must be an integer
-- Room number must be an integer
+- The floor number must be a **positive integer between** 1 and 99 **inclusive**.
+- The room number must be a **positive integer between** 100 and 999 **inclusive**.
 - Room type must be one of the following values: `CA` (corridor, aircon), `CN` (corridor, non-aircon), `NA` (non-corridor, aircon), `NN` (non-corridor, non-aircon)
 - The room will not be added if any piece of required information is missing. An error message will be displayed instead.
 

--- a/src/main/java/seedu/resireg/model/room/Floor.java
+++ b/src/main/java/seedu/resireg/model/room/Floor.java
@@ -10,7 +10,7 @@ import static seedu.resireg.commons.util.AppUtil.checkArgument;
 public class Floor {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Floors should only contain numbers, cannot start with 0 and it should be at most 2 digits long";
+            "Floor numbers should only contain numbers, cannot start with 0 and should be at most 2 digits long";
 
     public static final String VALIDATION_REGEX = "^[1-9][0-9]?$";
     public final String value;

--- a/src/main/java/seedu/resireg/model/room/RoomNumber.java
+++ b/src/main/java/seedu/resireg/model/room/RoomNumber.java
@@ -11,7 +11,7 @@ public class RoomNumber {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Room numbers should only contain numbers, cannot start with 0 "
-                    + "and it should be at most 3 digits long";
+                    + "and should be 3 digits long";
 
     public static final String VALIDATION_REGEX = "^[1-9][0-9][0-9]$";
     public final String value;


### PR DESCRIPTION
### What this does
This PR edits the room number error message to better reflect the intended behaviour (room numbers have to be 3 digits long and cannot start with 0). This constraint for room numbers, as well as constraints for floor numbers have been added to the UG, specifically under `add-room` to reflect what valid inputs for the command are.

<!-- Delete accordingly -->
Fixes #155 and #160

### How to test
N/A

### Notes
<!-- Anything else we should take note of, e.g. how this affects future PRs,
issues faced, etc. -->
N/A
